### PR TITLE
Added UTF-8 meta tag to header.

### DIFF
--- a/src/templates/_includes/layouts/index.njk
+++ b/src/templates/_includes/layouts/index.njk
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <title>Drought.ca.gov</title>
+  <meta charset="UTF-8">
   <meta content="width=device-width,initial-scale=1" name="viewport">
   {% set css %}
   {% include "../../../css/index.css" %}


### PR DESCRIPTION
The site is currently defaulting to Windows-1252 on both Amazon and Cloudfront.  This is an attempt to correct that.

Symptom: 
![image](https://user-images.githubusercontent.com/287977/124520151-6beafc00-dda0-11eb-9592-0b17d7c7d43e.png)
