### PR TITLE
Added accordion and outbound-link tracking.

### DIFF
--- a/src/js/gatracker/index.js
+++ b/src/js/gatracker/index.js
@@ -15,4 +15,30 @@ function reportGA(eventAction, eventLabel, eventCategory = 'click') {
 
 export default function setupAnalytics() {
     console.log("Setting up analytics");
+
+    document.querySelectorAll('cagov-accordion').forEach((acc) => {
+        acc.addEventListener('click',function() {
+          if(this.querySelector('.accordion-title')) {
+            reportGA('accordion', this.querySelector('.accordion-title').textContent.trim())
+          }
+        });
+      });
+    
+      document.querySelectorAll('a').forEach((a) => {
+        // look for and track offsite and pdf links
+        if(a.href.indexOf(window.location.hostname) > -1 || a.href.indexOf('drought.ca.gov') > -1) {
+          if(a.href.indexOf('.pdf') > -1) {
+            a.addEventListener('click',function() {
+              reportGA('pdf', this.href.split(window.location.hostname)[1])
+            });    
+          }
+        } else {
+          // console.log("Adding offsite link handler:",window.location.hostname,a.href);
+          a.addEventListener('click',function() {
+            reportGA('offsite', this.href)
+          })
+        }
+      });
+    
+
 }


### PR DESCRIPTION
This is essentially the same code as in Covid19. 

We don't have any accordion instances yet, but I see the developer-sample code uses identical markup. It assumes
the canonical URL of the site is drought.ca.gov and treats anything else as an out-bound link.