### PR TITLE
2021 07 15/content nav page cleanup

### DIFF
--- a/src/components/accordion/_style.scss
+++ b/src/components/accordion/_style.scss
@@ -17,7 +17,5 @@ cagov-accordion.prog-enhanced button.accordion-card-header {
 }
 
 button.accordion-card-header:hover .accordion-title:hover {
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-position: under;
+    @include text-underline;
 }

--- a/src/components/breadcrumb/index.scss
+++ b/src/components/breadcrumb/index.scss
@@ -8,12 +8,10 @@
 }
 
 .breadcrumb a {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
+  @include text-underline;
   margin-left: 5px;
   margin-right: 5px;
   display: inline-block;
-  text-underline-position: under;
 }
 
 .breadcrumb span {

--- a/src/components/content-navigation/index.scss
+++ b/src/components/content-navigation/index.scss
@@ -1,55 +1,49 @@
 /* CONTENT NAVIGATION */
-sidebar cagov-content-navigation .label {
-  font-weight: 700;
-  font-size: 24px;
-  line-height: 28.2px;
-  padding: 0;
-  margin: 0;
-  padding-bottom: 16px;
+
+cagov-content-navigation {
+  .label {
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 28.2px;
+    padding: 0;
+    margin: 0;
+    padding-bottom: 16px;
+  }
+
+  ul, ol {
+    margin: 0;
+    text-indent: 0;
+    padding: 0;
+  }
+
+  li {
+    padding-top: 16px;
+    margin-top: 16px;
+    border-top: 1px solid #EDEDEF;
+    line-height: 28.2px;
+    list-style: none;
+  }
+
+  li:first-child {
+    margin-top: 0px;
+  }
+} 
+
+@include phone {
+  cagov-content-navigation {
+    .label {
+      display: none;
+      a {
+        font-size: 16px;
+        line-height: 24px;
+      }
+    }
+    ul li:last-child {
+      padding-bottom: 16px;
+      margin-bottom: 16px;
+      border-bottom: 1px solid #EDEDEF;
+    }
+  }
 }
 
-sidebar cagov-content-navigation ul,
-sidebar cagov-content-navigation ol:not([class*="menu"]):not([class*="nav"]):not([class*="footer-links"]),
-sidebar cagov-content-navigation ul:not([class*="menu"]):not([class*="nav"]):not([class*="footer-links"]) {
-  margin: 0;
-  text-indent: 0;
-  padding: 0;
-}
-
-sidebar cagov-content-navigation ul li {
-  padding-top: 16px;
-  margin-top: 16px;
-  border-top: 1px solid #EDEDEF;
-  line-height: 28.2px;
-  list-style: none;
-}
-
-sidebar cagov-content-navigation ul li:first-child {
-  margin-top: 0px;
-}
-
-@media only screen and (max-width: 992px) {
-cagov-content-navigation .label {
-  display: none;
-}
-
-.sidebar-container {
-  display: block;
-  width: 100%;
-  max-width: 100%;
-}
-
-sidebar cagov-content-navigation ul li:last-child {
-  padding-bottom: 16px;
-  margin-bottom: 16px;
-  border-bottom: 1px solid #EDEDEF;
-}
-
-cagov-content-navigation ul li a {
-  font-size: 16px;
-  line-height: 24px;
-}
-
-
-}
 

--- a/src/components/menu/_style.scss
+++ b/src/components/menu/_style.scss
@@ -319,7 +319,7 @@ cagov-navoverlay {
             background: transparent;
           }
           &:hover {
-            text-decoration: underline;
+            @include text-underline;
             color: darken($color: $primary, $amount: 15%);
           }
 

--- a/src/components/post-list/_style.scss
+++ b/src/components/post-list/_style.scss
@@ -1,50 +1,3 @@
-/* @TODO These px values need to be converted to relative values */
-/* @TODO Align with typography & styles: Font, px spacing, colors */
-/* @TODO Figure out editor theme styles & if it conflicts with the display of this block/web-component. */
-
-// .cagov-announcement-list h3 {
-//   /* font-family: Public Sans; */
-//   font-style: normal;
-//   font-weight: bold;
-//   font-size: 28px;
-//   line-height: 33px;
-//   margin-bottom: 24px !important;
-// }
-
-// .cagov-announcement-list .read-more a {
-//   /* font-family: Public Sans; */
-//   font-style: normal;
-//   font-weight: normal;
-//   font-size: 18px;
-//   line-height: 30px;
-//   text-decoration: underline;
-//   color: #000;
-// }
-
-// .cagov-announcement-list .post-list-item {
-//   margin: 0;
-//   padding: 0;
-// }
-
-// .cagov-announcement-list .post-list-item {
-//   list-style: none;
-//   font-style: normal;
-//   font-weight: normal;
-//   margin-bottom: 24px;
-// }
-
-// .cagov-announcement-list .post-list-item .date {
-//   font-size: 18px;
-//   line-height: 30px;
-//   margin-top: 0px;
-//   color: #000;
-// }
-
-/* @TODO These px values need to be converted to relative values */
-/* @TODO Align with typography & styles: Font, px spacing, colors, css vars, breakpoints  */
-/* @TODO Figure out editor theme styles & if it conflicts with the display of this block/web-component. */
-
-
 .cagov-post-list .post-list-item {
   margin-bottom: 48px;
   .excerpt .date {
@@ -59,7 +12,7 @@
 .cagov-post-list .link-title a {
   color: $primary;
   font-weight: normal;
-  text-decoration: underline;
+  @include text-underline;
   font-size: 18px;
   line-height: 30px;
   margin-bottom: 8px;
@@ -72,9 +25,7 @@
   font-size: 28px;
   margin-bottom: 16px;
   a {
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-position: under;
+    @include text-underline;
   }
 }
 
@@ -108,9 +59,7 @@
   font-weight: 700;
   line-height: 30px;
   font-size: 28px;
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-position: under;
+  @include text-underline;
 }
 
 .cagov-post-list .excerpt,
@@ -165,9 +114,7 @@ cagov-post-list .post-list-item {
     line-height: 30px;
     font-size: 24px;
     margin-bottom: 8px;
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-position: under;
+    @include text-underline;
   }
 
   .cagov-post-list .excerpt,

--- a/src/css/sass/_links.scss
+++ b/src/css/sass/_links.scss
@@ -8,7 +8,6 @@ a {
     outline: 2px solid $secondary;
   }
 
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-position: under;
+  @include text-underline;
+
 }

--- a/src/css/sass/_mixins.scss
+++ b/src/css/sass/_mixins.scss
@@ -23,3 +23,10 @@
     @content;
   }
 }
+
+@mixin text-underline {
+  text-decoration: underline;
+  // text-decoration-thickness: 1px;
+  // text-underline-position: under;
+  // text-underline-offset: -0.05em;
+}

--- a/src/css/sass/_normalize.scss
+++ b/src/css/sass/_normalize.scss
@@ -1,0 +1,21 @@
+/* beginnings of normalize */
+*,
+:after,
+:before {
+  box-sizing: border-box;
+  background-color: inherit;
+  font-family: inherit;
+  color: inherit;
+  overflow-wrap: break-word;
+  margin: 0;
+  padding: 0;
+  border: 0 solid;
+}
+
+body {
+    font-family: $site-font;
+    font-size: $body-text;
+    line-height: 1.5;
+    color: $black;
+  }
+  

--- a/src/css/sass/_page.scss
+++ b/src/css/sass/_page.scss
@@ -19,8 +19,20 @@ article {
 
 /* Single column layout */
 .single-column {
+  max-width: $w-page-content;
+  margin: 0 auto;
+}
+
+.single-column.landing {
   max-width: $w-lg;
   margin: 0 auto;
+}
+
+.has-sidebar-left {
+  .single-column {
+    max-width: $w-lg;
+    margin: 0 auto;
+  }
 }
 
 @include tablet-buffer {

--- a/src/css/sass/_page.scss
+++ b/src/css/sass/_page.scss
@@ -1,30 +1,3 @@
-/* beginnings of normalize */
-*, :after, :before {
-  box-sizing: border-box;
-  background-color: inherit;
-  font-family: inherit;
-  color: inherit;
-  overflow-wrap: break-word;
-  margin: 0;
-  padding: 0;
-  border: 0 solid;
-}
-
-body {
-  font-family: $site-font;
-  font-size: $body-text;
-  line-height: 1.5;
-  color: $black;
-}
-
-/**
- CA Design System Page layout CSS
-*/
-
-/* PAGE CONTAINER */
-/* Design system page container */
-
-/* First Block has a top margin */
 #main-content {
   margin-top: 32px;
   margin-bottom: 64px;
@@ -40,35 +13,26 @@ body {
   max-width: 100%;
 }
 
+article {
+  display: block;
+}
+
 /* Single column layout */
 .single-column {
   max-width: $w-lg;
   margin: 0 auto;
 }
 
-
-/* CONTENT FOOTER */
-.content-footer-container {
-  border-bottom: 1px solid $gray-200;
-  border-top: 1px solid $gray-200;
-  padding-top: 23px;
-  padding-bottom: 23px;
+@include tablet-buffer {
+  .header-container,
+  .footer-container,
+  .page-container-ds {
+    margin-left: 15px;
+    margin-right: 15px;
+  }
 }
 
-.content-footer {
-  max-width: $w-lg !important;
-  margin-right: auto;
-  margin-left: auto;
-  /*padding-left: 15px;
-  padding-right: 15px;*/
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: flex-start;
-}
-
-/* PAGE BEHAVIORS */
-
+/* Responsive title behavior */
 /* Hide Mobile title, lives outside flex aligned elements and before content navigation, desktop page title is inside main. */
 .narrow-page-title {
   display: none;
@@ -83,100 +47,136 @@ body {
   }
 }
 
-/* Gutenberg Block alignment */
-
-/* Class applied to most external element of a gutenberg block component. Controls spacing between blocks. */
-.cagov-stack {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
+/* Responsive page title */
+.wide-page-title {
+  display: none;
 }
 
-/* Apply same spacing mechanism as cagov-stack, but overriding default gutenberg block element classes */
-.wp-block-columns {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-  display: flex;
-  flex-wrap: nowrap;
+.narrow-page-title {
+  display: block;
+  margin-bottom: 16px;
+  margin-top: 16px;
 }
 
-.wp-block-column {
-  flex-basis: 0;
-  flex-grow: 1;
-  min-width: 0;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  margin-top: 0px;
-  margin-bottom: 0px;
-}
-
-.wp-block-column:first-child {
-  margin-right: 32px;
-}
-
-/* Update position list element */
-main ul li {
-  list-style-position: outside;
-  margin-left: 32px;
-}
-
-@include tablet {
-
-  .with-sidebar .main-content-default,
-  .with-sidebar .ds-content-layout {
-    display: block;
-  }
-
-  article {
-    display: block;
-  }
-
-  .with-sidebar.page-container-ds #main-content.main-content-ds,
-  .with-sidebar.page-container-ds #main-content.main-content-ds main {
-    margin-top: 0;
-    margin-left: 0;
-  }
-
-  .with-sidebar.page-container-ds main {
-    margin-left: inherit;
-    margin-top: 32px;
-  }
-
-  /* Responsive page title */
+.main-content-ds.single-column {
   .wide-page-title {
     display: none;
   }
+}
 
+.main-content-ds.single-column.landing {
+  .wide-page-title {
+    display: none;
+  }
   .narrow-page-title {
+    display: none;
+  }
+}
+
+.sidebar-container {
+  display: block;
+  width: 276px;
+  max-width: 276px;
+  padding-right: $p-md;
+}
+
+.with-sidebar {
+  .main-content-default,
+  .ds-content-layout {
+    display: flex;
+    flex-wrap: wrap;
+    margin: calc(var(--s1) / 2 * -1);
+  }
+
+  &.has-sidebar-left .main-content-default > *,
+  &.has-sidebar-left .main-content-ds .ds-content-layout > .everylayout {
+    margin: calc(var(--s1) / 2);
+    flex-basis: 267px;
+    flex-grow: 1;
+  }
+
+  &.has-sidebar-left .main-content-default > :last-child,
+  &.has-sidebar-left
+    .main-content-ds
+    .ds-content-layout
+    > .everylayout:last-child {
+    flex-basis: 0;
+    flex-grow: 999;
+    min-width: calc(50% - var(--s1));
+  }
+
+  &.has-sidebar-right .main-content-default,
+  &.has-sidebar-right .main-content-ds .ds-content-layout > .everylayout {
+    flex-basis: 0;
+    flex-grow: 999;
+    min-width: calc(50% - var(--s1));
+  }
+
+  &.has-sidebar-right .main-content-default > * > :last-child,
+  &.has-sidebar-right .main-content-ds .ds-content-layout > :last-child {
+    margin: calc(var(--s1) / 2);
+    flex-basis: 267px;
+    flex-grow: 1;
+  }
+
+  .page-container-ds.has-sidebar-left main {
+    margin-left: 64px;
+    margin-right: 20px;
+  }
+
+  .page-container-ds.has-sidebar-right main {
+    margin-right: 64px;
+    margin-left: 20px;
+  }
+
+  .main-container-ds {
+    max-width: 877px;
+  }
+}
+
+/* footer */
+.content-footer-container {
+  border-bottom: 1px solid $gray-200;
+  border-top: 1px solid $gray-200;
+  padding-top: 23px;
+  padding-bottom: 23px;
+}
+
+.content-footer {
+  max-width: $w-lg !important;
+  margin-right: auto;
+  margin-left: auto;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
+@include phone {
+  .with-sidebar {
+    .main-content-default,
+    .ds-content-layout {
+      display: block;
+    }
+
+    &.page-container-ds main {
+      margin-left: inherit;
+      margin-top: 32px;
+    }
+
+    main {
+      margin-top: 0;
+      margin-left: 0;
+    }
+  }
+
+  /* sidebar */
+  .sidebar-container {
     display: block;
-    margin-bottom: 16px;
-    margin-top: 16px;
+    width: 100%;
+    max-width: 100%;
+    padding-right: $p-md;
   }
-
-  .main-content-ds.single-column {
-    .wide-page-title {
-      display: none;
-    }
-  }
-
-
-  main .wp-block-image img {
-    width:100%;
-    height: auto;
-    object-fit: cover;
-    object-position: bottom;
-    margin-bottom: 32px;
-  }
-
-  .main-content-ds.single-column.landing {
-    .wide-page-title {
-      display: none;
-    }
-    .narrow-page-title {
-      display: none;
-    }
-  }
-
-
 
   /* Content Menu */
   .content-footer {
@@ -185,108 +185,4 @@ main ul li {
     justify-content: flex-start;
     align-items: flex-start;
   }
-
-  .wp-block-columns {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
-    display: flex;
-    flex-wrap: nowrap;
-    flex-direction: column;
-  }
-  
-  .wp-block-column {
-    flex-basis: 0;
-    flex-grow: 1;
-    min-width: 0;
-    word-break: break-word;
-    overflow-wrap: break-word;
-    margin-top: 0px;
-    margin-bottom: 0px;
-  }
-  
-}
-@include tablet-buffer {
-  .header-container,
-  .footer-container,
-  .page-container-ds {
-    margin-left: 15px;
-    margin-right: 15px;
-  }
-}
-
-/* border styles */
-.wp-block-table {
-  background: none !important;
-  border: none !important;
-}
-.wp-block-table table,
-.wp-block-table table th,
-.wp-block-table table td {
-  border: 1px solid $gray-200 !important;
-}
-
-
-/* SIDEBAR */
-/* Based on EveryLayout sidebar: https://every-layout.dev/layouts/sidebar/. 
- Intention: We are keeping a clean and clear page-container so that we can do more css for design prototypes without requiring full integration with Wordpress Theme until user testing and research has concluding and layouts and templates are finalized.
- We are interested to use more of these kinds of layouts. 
- Talk to Koji for more information.
- See also: https://shop.smashingmagazine.com/products/inclusive-design-patterns
-
- Integration with CAWeb theme. For any main page elements that need to also render in the default template, the suffix is -default for layouts in the main theme, and -ds for layouts that are tied to templates provided by the design system WP code.
-*/
-
-.sidebar-container {
-  display: block;
-  width: 276px;
-  max-width: 276px;
-}
-
-.with-sidebar .main-content-default,
-.with-sidebar .ds-content-layout {
-  display: flex;
-  flex-wrap: wrap;
-  margin: calc(var(--s1) / 2 * -1);
-}
-
-.with-sidebar.has-sidebar-left .main-content-default > *,
-.with-sidebar.has-sidebar-left .main-content-ds .ds-content-layout > .everylayout {
-  margin: calc(var(--s1) / 2);
-  flex-basis: 267px;
-  flex-grow: 1;
-}
-
-.with-sidebar.has-sidebar-left .main-content-default > :last-child,
-.with-sidebar.has-sidebar-left .main-content-ds .ds-content-layout > .everylayout:last-child {
-  flex-basis: 0;
-  flex-grow: 999;
-  min-width: calc(50% - var(--s1));
-}
-
-.with-sidebar.has-sidebar-right .main-content-default,
-.with-sidebar.has-sidebar-right .main-content-ds .ds-content-layout > .everylayout {
-  flex-basis: 0;
-  flex-grow: 999;
-  min-width: calc(50% - var(--s1));
-}
-
-.with-sidebar.has-sidebar-right .main-content-default > * > :last-child,
-.with-sidebar.has-sidebar-right .main-content-ds .ds-content-layout > :last-child {
-  margin: calc(var(--s1) / 2);
-  flex-basis: 267px;
-  flex-grow: 1;
-}
-
-.with-sidebar.page-container-ds.has-sidebar-left main {
-  margin-left: 64px;
-  margin-right: 20px;
-}
-
-.with-sidebar.page-container-ds.has-sidebar-right main {
-  margin-right: 64px;
-  margin-left: 20px;
-}
-
-.with-sidebar .main-container-ds {
-  max-width: 877px;
 }

--- a/src/css/sass/_typography.scss
+++ b/src/css/sass/_typography.scss
@@ -25,6 +25,12 @@ ul li {
   margin-bottom: 0.5rem;
 }
 
+/* Update position list element */
+main ul li {
+  list-style-position: outside;
+  margin-left: 32px;
+}
+
 h1,
 .h1 {
   font-size: 2.5rem;

--- a/src/css/sass/_variables.scss
+++ b/src/css/sass/_variables.scss
@@ -13,6 +13,9 @@ $w-md: 960px;
 $w-sm: 720px;
 $w-xs: 540px;
 
+// Page container widths
+$w-page-content: 876px;
+
 // Font sizes
 $body-text: 1.125rem;
 $lead-text: 1.5rem;

--- a/src/css/sass/_wordpress.scss
+++ b/src/css/sass/_wordpress.scss
@@ -1,0 +1,69 @@
+/* Gutenberg Block alignment */
+
+/* Class applied to most external element of a gutenberg block component. Controls spacing between blocks. */
+.cagov-stack {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+/* Apply same spacing mechanism as cagov-stack, but overriding default gutenberg block element classes */
+.wp-block-columns {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.wp-block-column {
+  flex-basis: 0;
+  flex-grow: 1;
+  min-width: 0;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.wp-block-column:first-child {
+  margin-right: 32px;
+}
+
+/* border styles */
+.wp-block-table {
+  background: none !important;
+  border: none !important;
+}
+.wp-block-table table,
+.wp-block-table table th,
+.wp-block-table table td {
+  border: 1px solid $gray-200 !important;
+}
+
+main .wp-block-image img {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+    object-position: bottom;
+    margin-bottom: 32px;
+    max-width: 100%;
+  }
+
+@include phone {
+  .wp-block-columns {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: column;
+  }
+
+  .wp-block-column {
+    flex-basis: 0;
+    flex-grow: 1;
+    min-width: 0;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    margin-top: 0px;
+    margin-bottom: 0px;
+  }
+}

--- a/src/css/sass/index.scss
+++ b/src/css/sass/index.scss
@@ -7,7 +7,9 @@
 /* sitewide styles, these are mostly blank but will be wrapped up into components/base-css */
 @import './_fonts'; /* website global fonts */
 @import './_cagov-font'; /* website global fonts */
+@import './_normalize'; /* html, body, main and all the website level base styes */
 @import './_page'; /* html, body, main and all the website level base styes */
+@import './_wordpress'; /* a, a:hover, a:focus */
 @import './_buttons'; /* buttons generic styles */
 @import './_code'; /* pre, code, var generic styles */
 @import './_forms'; /* input, textarea, select generic styles */


### PR DESCRIPTION
* Reorganize the page scss file
* Add file for wordpress specific css (coming from gutenberg blocks)
* Add normalize file
* Make mixin for text underlining & revert back to default underline, will test further for firefox & at more zoom sizes.
* Fix alignment content nav