### PR TITLE
Added statewide Google Analytics tracking code.

### DIFF
--- a/src/js/gatracker/index.js
+++ b/src/js/gatracker/index.js
@@ -3,7 +3,7 @@
 function reportGA(eventAction, eventLabel, eventCategory = 'click') {
     if(typeof(ga) !== 'undefined') {
       ga('send', 'event', eventCategory, eventAction, eventLabel);
-      //   ga('tracker2.send', 'event', eventCategory, eventAction, eventLabel);
+      ga('tracker2.send', 'event', eventCategory, eventAction, eventLabel);
       //   ga('tracker3.send', 'event', eventCategory, eventAction, eventLabel);
     } else {
       setTimeout(function() {

--- a/src/templates/_includes/footer.njk
+++ b/src/templates/_includes/footer.njk
@@ -2,8 +2,10 @@
 <script>
 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 ga('create', 'UA-21970760-32', 'auto');
+ga('create', 'UA-3419582-2', 'tracker2');
 ga('set', 'transport', 'beacon');
 ga('send', 'pageview');
+ga('tracker2.send', 'pageview');
 </script>
 <script async defer src='https://www.google-analytics.com/analytics.js'></script>
 


### PR DESCRIPTION
Added a second tracking code so that drought.ca.gov can be tracked at the statewide level.