### PR TITLE
Changed styling for hover states based on Adam's preferences.

### DIFF
--- a/src/components/hero/index.scss
+++ b/src/components/hero/index.scss
@@ -58,7 +58,7 @@
   .wp-block-button:not(.is-style-outline)
   .wp-block-button__link:hover {
   /* defined here for when css vars are not supported */
-  background-color: var(--primary-color, #33705b);
+  background-color: var(--primary-hover-color, #33705b);
   /* variable used with fallback in case it is not defined */
   color: var(--white, #ffffff);
   padding: 0.5rem 1rem;
@@ -66,7 +66,7 @@
   font-weight: bold;
   display: inline-block;
   border: none;
-  text-decoration: underline;
+  // text-decoration: underline;
 }
 
 .cagov-hero-body-content .wp-block-button__link {

--- a/src/components/post-list/_style.scss
+++ b/src/components/post-list/_style.scss
@@ -16,6 +16,10 @@
   font-size: 18px;
   line-height: 30px;
   margin-bottom: 8px;
+  &:hover {
+    color: $primary-dark;
+    text-decoration: none;
+  }
 }
 
 .cagov-post-list .link-title,
@@ -26,6 +30,9 @@
   margin-bottom: 16px;
   a {
     @include text-underline;
+    &:hover {
+      text-decoration: none;
+    }
   }
 }
 
@@ -60,6 +67,10 @@
   line-height: 30px;
   font-size: 28px;
   @include text-underline;
+  &:hover {
+    color: $primary-dark;
+    text-decoration: none;
+  }
 }
 
 .cagov-post-list .excerpt,
@@ -115,6 +126,10 @@ cagov-post-list .post-list-item {
     font-size: 24px;
     margin-bottom: 8px;
     @include text-underline;
+    &:hover {
+      color: $primary-dark;
+      text-decoration: none;
+    }
   }
 
   .cagov-post-list .excerpt,

--- a/src/css/colorschemes/drought.css
+++ b/src/css/colorschemes/drought.css
@@ -2,7 +2,7 @@
 /* Colorscheme root variables */
 :root {
   --primary-color: #691808;
-  --primary-hover-color: #043747;
+  --primary-hover-color: #4a1106;
   --standout-color: #313131;
   --standout-hover-color: #21351f;
   --secondary-color: #cf5d28;

--- a/src/css/sass/_links.scss
+++ b/src/css/sass/_links.scss
@@ -2,7 +2,8 @@
 a {
   color: $primary;
   &:hover {
-    color: darken($color: $primary, $amount: 15%);
+    color: $primary-dark;
+    text-decoration: none;
   }
   &:focus {
     outline: 2px solid $secondary;


### PR DESCRIPTION
Adam's comments on Drought Q/A:

For inline text links, use the following hover state: No underline, #4a1106. ($primary-dark)

For menu links, use the following hover state: underline, #4a1106 ($primary-dark)

For primary buttons, use the following hover state: no underline, background color #4a1106

This fixes the inline text links and the primary buttons, as described above.