### PR TITLE
Fixed build redundancy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.html",
   "scripts": {
     "sass:compile": "node-sass --source-map true src/css/sass/ -o dist/",
-    "sass:build": "npm run sass:compile && npm run build:regen",
-    "sass:watch": "chokidar 'src/**/*.scss' -c 'npm run sass:build'",
+    "sass:build": "npm run sass:compile",
+    "sass:watch": "chokidar 'src/**/*.scss' -c 'npm run sass:build && npm run build:regen'",
     "build:regen": "npx @11ty/eleventy",
     "build:watch": "npx @11ty/eleventy --watch",
     "js:watch": "chokidar 'src/**/*.js' -c 'npm run js:bundle && npm run build:regen'",


### PR DESCRIPTION
As written, there was a redundancy in the build in both the 'dev' and 'build' steps called build:regen twice (because it was included in the sass:build step, and also at the end of the command).  I've moved build:regen from the sass:build step to the sass:watch command (which calls sass:build, and needs a subsequent build).  This removes the redundancy from the dev and build commands.

Note: There is still an ongoing issue I am investigating, in which touching eleventy.js (as well as some, but other lower level files) causes two simultaneous builds.