### PR TITLE
Fixed the double build issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,10 @@
     "sass:build": "npm run sass:compile",
     "sass:watch": "chokidar 'src/**/*.scss' -c 'npm run sass:build && npm run build:regen'",
     "build:regen": "npx @11ty/eleventy",
-    "build:watch": "npx @11ty/eleventy --watch",
     "js:watch": "chokidar 'src/**/*.js' -c 'npm run js:bundle && npm run build:regen'",
     "js:bundle": "rollup --config rollup.config.js",
     "start": "npx @11ty/eleventy --serve",
-    "dev": "npm-run-all -p sass:build js:bundle sass:watch js:watch build:watch start",
+    "dev": "npm-run-all -p sass:build js:bundle sass:watch js:watch start",
     "build": "npm-run-all -s js:bundle sass:build build:regen"
   },
   "keywords": [],


### PR DESCRIPTION
There was an issue with the build configuration in which touching certain files (.eleventy.js, or footer.njk, for example) would cause double builds.  The message "File Changed" would appear twice, and two builds would be triggered simultaneously.  A "Writing file" message would appear twice for each file.  When files normally watched by chokidar were changed (e.g. a scss or js file) this did _not_ happen.  No such "File change" message appeared, and the build occurred once. 

Double builds also occured in the initial compile sequence when one ran "npm run dev", which made it less efficient.

I found this was caused by the use of the build:watch step which included a "--watch" parameter.  Our use of --serve causes this behavior to already be in place;the extra --watch causes the extra builds.    I removed this command and substituted build:regen where 11ty builds are desired.  In the command used for "npm run dev" I eliminated the redundant watch step.

Now all the above files can be modified, and will trigger builds, but there are no redundant builds.

Perhaps worth checking if the Cannabis repo has a similar issue...
