### PR TITLE
Modified styling of footer, per Adam's directives.

### DIFF
--- a/src/components/cards/index.scss
+++ b/src/components/cards/index.scss
@@ -3,7 +3,7 @@
 }
 
 .cagov-card {
-  border: 1px solid #ededef;
+  border: 1px solid var(--gray-200, #ededef);
   padding: 1rem;
   border-bottom: 0.3rem solid #33705B;
   border-bottom: 0.3rem solid var(--primary-color, #33705B);

--- a/src/components/content-navigation/index.scss
+++ b/src/components/content-navigation/index.scss
@@ -19,7 +19,7 @@ cagov-content-navigation {
   li {
     padding-top: 16px;
     margin-top: 16px;
-    border-top: 1px solid #EDEDEF;
+    border-top: 1px solid var(--gray-200, #ededef);
     line-height: 28.2px;
     list-style: none;
   }
@@ -41,7 +41,7 @@ cagov-content-navigation {
     ul li:last-child {
       padding-bottom: 16px;
       margin-bottom: 16px;
-      border-bottom: 1px solid #EDEDEF;
+      border-bottom: 1px solid var(--gray-200, #ededef);
     }
   }
 }

--- a/src/components/footer/_style.scss
+++ b/src/components/footer/_style.scss
@@ -45,8 +45,10 @@ footer {
 	.cagov-logo {
 		padding: 5px 2rem 5px 0;
 		svg {
+			width:45px;
+			height:36px;
 			padding: 0;
-			padding-top: 6px;
+			padding-top: 0px;
 			.ca {
 				fill: $cagov-branding-primary;
 			}

--- a/src/components/footer/_style.scss
+++ b/src/components/footer/_style.scss
@@ -22,7 +22,7 @@ footer {
 	.footer-secondary-links {
 		display: flex;
 		flex-direction: column;
-		font-size: 1.2rem;
+		font-size: 1.0rem;
 
 		a {
 			margin-right: 1.7rem;
@@ -44,7 +44,18 @@ footer {
 
 	.cagov-logo {
 		padding: 5px 2rem 5px 0;
+		svg {
+			padding: 0;
+			padding-top: 6px;
+			.ca {
+				fill: $cagov-branding-primary;
+			}
+			.gov {
+				fill: $cagov-branding-secondary;
+			}
+		}
 	}
+
 
 	.bg-light-grey a,
 	.copyright {

--- a/src/components/footer/footer.html
+++ b/src/components/footer/footer.html
@@ -3,7 +3,7 @@
         <div class="container">
             <a href="https://ca.gov" class="cagov-logo" title="ca.gov" target="_blank">
                 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-                    y="0px" width="34px" height="34px" viewBox="0 0 44 34" style="enable-background:new 0 0 44 34;"
+                    y="0px" width="44px" height="34px" viewBox="0 0 44 34" style="enable-background:new 0 0 44 34;"
                     xml:space="preserve">
 
                     <path class="ca" d="M27.4,14c0.1-0.4,0.4-1.5,0.9-3.2c0.1-0.5,0.4-1.3,0.9-2.7c0.5-1.4,0.9-2.5,1.2-3.3c-0.9,0.6-1.8,1.4-2.7,2.3

--- a/src/components/site-footer/_style.scss
+++ b/src/components/site-footer/_style.scss
@@ -8,6 +8,8 @@ section.site-footer {
 		max-width: $w-lg;
 		margin: 0 auto;
 		padding: 1rem 0;
+		border-top: 1px solid var(--gray-200,#EDEDEF);
+		border-bottom: 1px solid var(--gray-200,#EDEDEF);
 	}
 
 	a {


### PR DESCRIPTION
"Make consistent with Cannabis by:
DONE Adding 1px #EDEDEF top border above footer links
DONE Reducing size of statewide footer links (16px)
NOT DONE Using same statewide footer links as Cannabis. (requires editorial)
DONE Using same ca.gov logo as Cannabis"