### PR TITLE
Drought map build trigger

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -4,8 +4,10 @@ on:
     branches:
       - main
   workflow_run:
-    workflows: ["Generate Drought Map"]
-    types: [completed]
+    workflows: 
+      - "Generate Drought Map"
+    types: 
+      - completed
 jobs:
   build_deploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows: ["Generate Drought Map"]
+    types: [completed]
 jobs:
   build_deploy:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
We recently implemented a new GitHub Action to automate generation of our weekly drought map. The new drought map workflow is working, but its generated changes are not getting pushed to the live site. Where we expected completion of the drought map workflow to trigger the Eleventy Build Main workflow on push, it did not. [The reasons for this are described by GitHub here](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).

This PR represents one solution to this problem. Here, we add a trigger to Eleventy Build Main to run whenever the drought map workflow completes.