### PR TITLE
Add content nav to Current Drought Conditions

### DIFF
--- a/wordpress/pages/current-drought-conditions.json
+++ b/wordpress/pages/current-drought-conditions.json
@@ -38,7 +38,7 @@
       "launch content"
     ],
     "design_system_fields": {
-      "template": "template-page-single-column"
+      "template": "page"
     },
     "og_meta": {
       "_genesis_title": [


### PR DESCRIPTION
This simple PR adds content navigation to the Current Drought Conditions article. Screenshot attached. Let me know if y'all want to see this in staging beforehand.

<img width="1067" alt="Screen Shot 2021-09-28 at 16 16 02" src="https://user-images.githubusercontent.com/1208960/135178208-055c8503-db66-48e2-ad48-f77084eb24c7.png">

I'm assuming there's a flag in the publishing system that sets the layout for this article to "template-page-single-column". It will need to be set to "page" instead, to prevent future regressions.