### PR TITLE
Development merge scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "js:bundle": "rollup --config rollup.config.js",
     "start": "npx @11ty/eleventy --serve",
     "dev": "npm-run-all -p sass:build js:bundle sass:watch js:watch start",
-    "build": "npm-run-all -s js:bundle sass:build build:regen"
+    "build": "npm-run-all -s js:bundle sass:build build:regen",
+    "git:merge:dev-into-main": "./src/sh/git-merge-development-into-main.sh",
+    "git:merge:main-into-dev": "./src/sh/git-merge-main-into-development.sh"
   },
   "keywords": [],
   "author": "",

--- a/src/sh/git-merge-development-into-main.sh
+++ b/src/sh/git-merge-development-into-main.sh
@@ -4,6 +4,10 @@ git checkout development
 git pull
 git checkout main
 git pull
-git merge --no-ff --no-commit main
-git restore --source=HEAD --staged --worktree -- wordpress/posts wordpress/pages wordpress/media wordpress/config/wordpress-to-github.development.config.json
+git merge --no-ff --no-commit development
+git restore --source=HEAD --staged --worktree -- \ 
+    wordpress/posts \ 
+    wordpress/pages \ 
+    wordpress/media \ 
+    wordpress/config/wordpress-to-github.development.config.json
 git commit -m "Selective merge: development into main"

--- a/src/sh/git-merge-development-into-main.sh
+++ b/src/sh/git-merge-development-into-main.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+git fetch
+git checkout development
+git pull
+git checkout main
+git pull
+git merge --no-ff --no-commit main
+git restore --source=HEAD --staged --worktree -- wordpress/posts wordpress/pages wordpress/media wordpress/config/wordpress-to-github.development.config.json
+git commit -m "Selective merge: development into main"

--- a/src/sh/git-merge-main-into-development.sh
+++ b/src/sh/git-merge-main-into-development.sh
@@ -5,5 +5,8 @@ git pull
 git checkout development
 git pull
 git merge --no-ff --no-commit main
-git restore --source=HEAD --staged --worktree -- wordpress/posts wordpress/pages wordpress/media
+git restore --source=HEAD --staged --worktree -- \
+    wordpress/posts \
+    wordpress/pages \
+    wordpress/media
 git commit -m "Selective merge: main into development"

--- a/src/sh/git-merge-main-into-development.sh
+++ b/src/sh/git-merge-main-into-development.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+git fetch
+git checkout main
+git pull
+git checkout development
+git pull
+git merge --no-ff --no-commit main
+git restore --source=HEAD --staged --worktree -- wordpress/posts wordpress/pages wordpress/media
+git commit -m "Selective merge: main into development"


### PR DESCRIPTION
This PR adds merge scripts to safely migrate code between the `main` and `development` branches, without cross-environment content or config pollution.

Couple notes follow. 

* The main-to-development script currently fails due to merge conflict with `wordpress/wordpress-to-github.config.json`. I'm assuming we need to fix up this file in `development` anyway, since we want to use separate config files per environment (as discussed in #138). So this is a problem to fix in the `development` branch at some point.
* I see there's a new file, `wordpress/general/general.json`, added in the past few days. How does this new file relate to the old `wordpress-to-github.json` file, if at all? Should we consider this file when merging code between environments?
* The shell scripts should work for most Windows users thanks to [Git For Windows](https://gitforwindows.org/), but still, we should verify this. It's very Unix-y.