### PR TITLE
Drought map text changes

### DIFF
--- a/src/components/drought-map/index.js
+++ b/src/components/drought-map/index.js
@@ -20,7 +20,9 @@ class CAGovDroughtMap extends window.HTMLElement {
       if (data !== undefined && data !== null && data.content !== null) {
         if (type === "wordpress") {
           this.innerHTML = `<div class="cagov-drought-map">
-                <div class="map-label"><h3>Map released: ${latestDroughtMap.dateString}</h3></div>
+                <p class="map-label">Released ${latestDroughtMap.dateString}</p>
+
+                <p>Click the map to see the intensity of drought conditions in California:</p>
                 <div class="drought-map-container">
                   <div class="drought-map-image"><a href="https://droughtmonitor.unl.edu/"><img src="${latestDroughtMap.filePath}" /></a></div>
                   <div class="legend-label"><h4>Intensity</h4></div>

--- a/src/components/drought-map/index.scss
+++ b/src/components/drought-map/index.scss
@@ -19,7 +19,7 @@
         }
     }
     .legend-label, .map-label {
-
+        font-style: italic;
     }
     .map-link {
         margin-top:12px;


### PR DESCRIPTION
This PR changes arrangement of a few lines of text for the Drought Map. See screenshot for preview. 

Note that the "Click the map to see the intensity of drought conditions in California" line has been embedded into the code here, and would need to be removed from Wordpress content once this change is pushed live.

<img width="898" alt="Screen Shot 2021-10-06 at 09 43 07" src="https://user-images.githubusercontent.com/1208960/136249662-b6401614-dc21-4418-96f9-dbf7cd467b68.png">
