### PR TITLE
Bump ds-base-css to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@cagov/ds-accordion": "^1.0.3",
-        "@cagov/ds-base-css": "^1.0.1",
+        "@cagov/ds-base-css": "^1.0.7",
         "@cagov/ds-branding": "^1.0.3",
         "@cagov/ds-dropdown-menu": "^1.0.12",
         "@cagov/ds-feedback": "^1.0.5",
@@ -209,9 +209,9 @@
       "integrity": "sha512-Jk2O63a5W9A1Db39EQpwjbb30cEEpJkgEU7kcampkujmAMfS+ygbHRf9ctAcs3ZN4AgRokfZhj2YiHLnWvt3MQ=="
     },
     "node_modules/@cagov/ds-base-css": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-base-css/-/ds-base-css-1.0.3.tgz",
-      "integrity": "sha512-LO42T6SB3Y3wcW53HVYcKikJIIjN5/p6Cq7sVaWNvIHB8ZVJMZUmfvGbx2Ngoy5sGeR3hMD+PjBYAMvNnQfPHg=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-base-css/-/ds-base-css-1.0.7.tgz",
+      "integrity": "sha512-oFycZ1YQTHh14eQvBntTxKAewarcjWt8H6S2/MIHXS9KOiYgREhBwJ2KwEBVxZSg0yItxeGSDcTMrvkV/ba56A=="
     },
     "node_modules/@cagov/ds-branding": {
       "version": "1.0.3",
@@ -8772,9 +8772,9 @@
       "integrity": "sha512-Jk2O63a5W9A1Db39EQpwjbb30cEEpJkgEU7kcampkujmAMfS+ygbHRf9ctAcs3ZN4AgRokfZhj2YiHLnWvt3MQ=="
     },
     "@cagov/ds-base-css": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cagov/ds-base-css/-/ds-base-css-1.0.3.tgz",
-      "integrity": "sha512-LO42T6SB3Y3wcW53HVYcKikJIIjN5/p6Cq7sVaWNvIHB8ZVJMZUmfvGbx2Ngoy5sGeR3hMD+PjBYAMvNnQfPHg=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cagov/ds-base-css/-/ds-base-css-1.0.7.tgz",
+      "integrity": "sha512-oFycZ1YQTHh14eQvBntTxKAewarcjWt8H6S2/MIHXS9KOiYgREhBwJ2KwEBVxZSg0yItxeGSDcTMrvkV/ba56A=="
     },
     "@cagov/ds-branding": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@cagov/ds-minus": "^1.0.0",
     "@cagov/ds-pagination": "^1.0.0",
 
-    "@cagov/ds-base-css": "^1.0.1",
+    "@cagov/ds-base-css": "^1.0.7",
     "@cagov/ds-branding": "^1.0.3",
     "@cagov/ds-dropdown-menu": "^1.0.12",
 


### PR DESCRIPTION
This PR bumps ds-base-css to version 1.0.7. The purpose of this fix is to fix font-weight on highlight lists.

Before:
<img width="921" alt="Screen Shot 2021-10-12 at 12 09 19" src="https://user-images.githubusercontent.com/1208960/137023886-1a774503-fc72-4cf3-ad0b-b3d48fa89455.png">

After:
<img width="906" alt="Screen Shot 2021-10-12 at 13 21 48" src="https://user-images.githubusercontent.com/1208960/137023902-1099d4a6-520b-4ad5-b017-7f43ad854a19.png">
