### PR TITLE
Fix date default and link formatting for posts

### DIFF
--- a/src/components/post-list/get-posts.js
+++ b/src/components/post-list/get-posts.js
@@ -41,12 +41,18 @@ const getPostsByCategory = (categoryString, count = 5, field = "custom_post_date
       }
     }
   });
-  return wordPressArray
+  
+  let postsToReturn = wordPressArray
     .sort((a, b) => {
-      return new Date(a.data[field]) - new Date(b.data[field]);
+      let aDate = a.data[field] ? a.data[field] : a.data.date;
+      let bDate = b.data[field] ? b.data[field] : b.data.date;
+      return new Date(aDate) - new Date(bDate);
     })
-    .slice(Math.max(wordPressArray.length - count, 0))
+    .slice(-count)
     .reverse();
+
+  //console.log(returnPosts.map(f => `${f.data.title}: ${f.data.custom_post_date}, ${f.data.date}`));
+  return postsToReturn;
 };
 
 module.exports = { getPostsByCategory };

--- a/src/components/post-list/render.js
+++ b/src/components/post-list/render.js
@@ -73,6 +73,7 @@ const renderWordpressPostTitleDate = (
     title = null,
     link = null,
     date = null, // "2021-05-23T18:19:58"
+    // modified = null,
     // content = null,
     excerpt = null, // @TODO shorten / optional
     // author = null, // 1
@@ -89,7 +90,7 @@ const renderWordpressPostTitleDate = (
   
   let itemDate = date;
 
-  if (custom_post_date !== null) {
+  if (custom_post_date && custom_post_date !== "") {
     itemDate = custom_post_date;
   }
 
@@ -123,12 +124,16 @@ const renderWordpressPostTitleDate = (
       ? `<div class="date">${dateFormatted}</div>`
       : ``;
 
-  let postLink;
+  let formattedTitle;
 
-  if (format === "link" && meta && meta.hasOwnProperty("custom_post_link")) {
-    postLink = meta.custom_post_link;
-  } else {
-    postLink = link ? link.split("pantheonsite.io")[1] : null;
+  if (format === "link" && meta && meta.hasOwnProperty("custom_post_link") && meta.custom_post_link !== "") {
+    formattedTitle = `<a href="${meta.custom_post_link}">${title}</a>`;
+  } 
+  else if (format !== "link") {
+    formattedTitle = link ? `<a href="${link.split("pantheonsite.io")[1]}">${title}</a>` : `<span>${title}</span>`;
+  }
+  else {
+    formattedTitle = `<span>${title}</span>`;
   }
 
   let category_type = "";
@@ -163,9 +168,7 @@ const renderWordpressPostTitleDate = (
       <div class="post-list-item">
         ${category_type}
         <div class="link-title">
-          <a href="${postLink}">
-            ${title}
-          </a>
+          ${formattedTitle}
         </div>
         ${getDate}
         ${getExcerpt}
@@ -177,9 +180,7 @@ const renderWordpressPostTitleDate = (
     <div class="post-list-item">
       ${category_type}
       <div class="link-title">
-        <a href="${postLink}">
-          ${title}
-        </a>
+        ${formattedTitle}
       </div>
       ${getDate}
       ${getExcerpt}


### PR DESCRIPTION
Per #166, fixes some display problems with News posts.

The conditionals for using the `custom_post_link` are starting to get complicated. One question that would resolve this: do we ever expect to use a `custom_post_link` on a post that's not of "link" format?