### PR TITLE
Change PR trigger type

### DIFF
--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -1,11 +1,11 @@
 name: Eleventy Build PR Site
 on:
   pull_request:
-    branches-ignore:
-      - main
-      - staging
-      - development
-      - main-test-pantheon
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
 jobs:
   build_deploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -64,7 +64,7 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Preview site available at [${URLSAFE_BRANCH_NAME}.pr.drought.ca.gov](https://${URLSAFE_BRANCH_NAME}.pr.drought.ca.gov/).
+            Preview site available at [${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov](https://${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov/).
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
           allow-repeats: false

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -64,7 +64,7 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Preview site available at [${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov](https://${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov/).
+            Preview site available at <a href="https://${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov/" target="_blank">${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov</a>.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
           allow-repeats: false

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -51,12 +51,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
           SOURCE_DIR: ./docs # only move built directory
-          DEST_DIR: /pr/${URLSAFE_BRANCH_NAME}
+          DEST_DIR: pr/${URLSAFE_BRANCH_NAME}
       - name: Invalidate CloudFront cache
         uses: chetan/invalidate-cloudfront-action@v1.3
         env:
           DISTRIBUTION: 'E2EGQV7PEACS1R'
-          PATHS: '/pr/${URLSAFE_BRANCH_NAME}'
+          PATHS: '/*'
           AWS_REGION: 'us-west-1'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -64,7 +64,7 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Preview site available at <a href="https://${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov/" target="_blank">${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov</a>.
+            Preview site available at [${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov](https://${{ env.URLSAFE_BRANCH_NAME }}.pr.drought.ca.gov/).
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
           allow-repeats: false


### PR DESCRIPTION
Quick fix to #211. I've changed the trigger type on the PR-site GitHub Action.

It turns out that `branches` within the pull_request trigger refers to the **target** branch, not the **source** branch. So the previous iteration of this Action did not behave as expected.