### PR TITLE
Add robots.txt

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -25,7 +25,11 @@ jobs:
           mkdir dist
           npm ci --production
           npm run build
-
+      - name: Write robots.txt
+        run: |
+          echo 'User-agent: *' > docs/robots.txt
+          echo 'Allow: /' >> docs/robots.txt
+          echo 'Sitemap: https://drought.ca.gov/sitemap.xml' >> docs/robots.txt
       # Push built site files to S3 production bucket    
       - name: Deploy to S3
         uses: jakejarvis/s3-sync-action@v0.5.1

--- a/.github/workflows/eleventy_build_development.yml
+++ b/.github/workflows/eleventy_build_development.yml
@@ -19,7 +19,10 @@ jobs:
         run: |
           npm ci --production
           npm run build
-
+      - name: Write robots.txt
+        run: |
+          echo 'User-agent: *' > docs/robots.txt
+          echo 'Disallow: /' >> docs/robots.txt
       # deploy built files to separate branch that contains only built files that github pages uses to serve site
       - name: Deploy to github pages branch
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/eleventy_build_main_test_pantheon.yml
+++ b/.github/workflows/eleventy_build_main_test_pantheon.yml
@@ -23,7 +23,10 @@ jobs:
           mkdir dist
           npm ci --production
           npm run build
-
+      - name: Write robots.txt
+        run: |
+          echo 'User-agent: *' > docs/robots.txt
+          echo 'Disallow: /' >> docs/robots.txt
       # # Push built site files to S3 production bucket    
       # - name: Deploy to S3
       #   uses: jakejarvis/s3-sync-action@v0.5.1

--- a/.github/workflows/eleventy_build_staging.yml
+++ b/.github/workflows/eleventy_build_staging.yml
@@ -20,7 +20,10 @@ jobs:
           mkdir dist
           npm ci --production
           npm run build
-
+      - name: Write robots.txt
+        run: |
+          echo 'User-agent: *' > docs/robots.txt
+          echo 'Disallow: /' >> docs/robots.txt
       # # Push built site files to S3 production bucket    
       # - name: Deploy to S3
       #   uses: jakejarvis/s3-sync-action@v0.5.1


### PR DESCRIPTION
Per #192, adds a proper robots.txt file to GH Action builds, based on branch. 

This also generates a different robots.txt file for `main` branch, in addition to non-`main` branches.