### PR TITLE
Menus, Part 1

### DIFF
--- a/odi-publishing/wordpress-to-github.config.json
+++ b/odi-publishing/wordpress-to-github.config.json
@@ -16,6 +16,21 @@
         "Destination": "src/templates/_data/headerMenu.json",
         "Source": "/wp-json/menus/v1/menus/header-menu",
         "ExcludeProperties": []
+      },
+      {
+        "Destination": "src/templates/_data/contentMenu.json",
+        "Source": "/wp-json/menus/v1/menus/content-menu",
+        "ExcludeProperties": []
+      },
+      {
+        "Destination": "src/templates/_data/stateWideFooterMenu.json",
+        "Source": "/wp-json/menus/v1/menus/state-wide-footer-menu",
+        "ExcludeProperties": []
+      },
+      {
+        "Destination": "src/templates/_data/socialMediaLinksMenu.json",
+        "Source": "/wp-json/menus/v1/menus/social-media-links-menu",
+        "ExcludeProperties": []
       }
     ]
   }

--- a/src/templates/_includes/nav-component.njk
+++ b/src/templates/_includes/nav-component.njk
@@ -25,7 +25,7 @@
             <a class="expanded-menu-section-header-link js-event-hm-menu" href="/">Home</a>
           </strong>
         </div>
-        {%-set headerLinks = menus['header-menu'].items -%}
+        {%-set headerLinks = headerMenu.items -%}
         {% for menu in headerLinks %}
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">

--- a/src/templates/_includes/nav-header.njk
+++ b/src/templates/_includes/nav-header.njk
@@ -1,7 +1,7 @@
 <nav id="navigation" class="main-navigation dropdown hidden-print nav" data-multiselectable="false"
   data-nav-id="hg9r92s58o">
   <ul id="nav_list" class="top-level-nav">
-    {%-set headerLinks = menus['header-menu'].items -%}
+    {%-set headerLinks = headerMenu.items -%}
     {% for menu in headerLinks %}
     <li class="nav-item menu-item menu-item-type-post_type menu-item-object-page" title="">
       <div class="has-sub-btn"><button class="first-level-btn nav-header has-sub" id="navz9mkgo0td82_tab1"


### PR DESCRIPTION
This PR does two things.

* Adds three additional API requests for more menus to `odi-publishing/wordpress-to-github.json`.
* Configures the site header to use `headerMenu.json` instead of `menus.js`. 

The goal here is to eliminate `menus.js` in favor of handling menu API requests via wordpress-to-github. 

There will need to be a follow-up PR (part 2) to replace the other three menus. That will be possible after corresponding data files have been deposited via this revised wordpress-to-github config.