### PR TITLE
put external-link-icon JS import after pdf-icon JS to fix #221

### DIFF
--- a/src/js/index-headless.js
+++ b/src/js/index-headless.js
@@ -5,8 +5,8 @@ import '@cagov/ds-pagination';
 import '@cagov/ds-plus';
 import '@cagov/ds-dropdown-menu';
 import '@cagov/ds-content-navigation';
-import '@cagov/ds-external-link-icon/src/index.js';
 import '@cagov/ds-pdf-icon/src/index.js';
+import '@cagov/ds-external-link-icon/src/index.js';
 import '@cagov/ds-back-to-top/src/index.js';
 
 import '../components/post-list/index.js';


### PR DESCRIPTION
we need to switch javaScript order, and it will fix [this](https://github.com/cagov/drought.ca.gov/issues/221) issue. (We have css in external link component that disables external link if pdf icon is present, but external link JavaScript needs to go after pdf icon JS because, unfortunately, there is no CSS Previous sibling selectors, only subsequent.)