### PR TITLE
Fix WP media domains

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -63,7 +63,7 @@ module.exports = function (eleventyConfig) {
         html = renderPostLists(html);
       }
       // Replace Wordpress media paths with correct 11ty output path.
-      const regexPattern = `http.+?(drought\.ca\.gov|localhost).*?/${config.build.upload_folder}`;
+      const regexPattern = `http.+?pantheonsite\.io/${config.build.upload_folder}`;
       html = html.replace(new RegExp(regexPattern, 'g'), "/media/");
       // Minify HTML.
       html = htmlmin.minify(html, {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -63,7 +63,8 @@ module.exports = function (eleventyConfig) {
         html = renderPostLists(html);
       }
       // Replace Wordpress media paths with correct 11ty output path.
-      html = html.replace(new RegExp(`http.+?/${config.build.upload_folder}`, 'g'), "/media/");
+      const regexPattern = `http.+?(drought\.ca\.gov|localhost).*?/${config.build.upload_folder}`;
+      html = html.replace(new RegExp(regexPattern, 'g'), "/media/");
       // Minify HTML.
       html = htmlmin.minify(html, {
         useShortDoctype: true,


### PR DESCRIPTION
This PR fixes a problem with the domain-name-switcher we apply to Wordpress media links. The current implementation sometimes modifies and breaks links to external sites (that share the same URL path structure as our own Wordpress media).