### PR TITLE
Update drought map link and update label

### DIFF
--- a/src/components/drought-map/index.js
+++ b/src/components/drought-map/index.js
@@ -20,11 +20,11 @@ class CAGovDroughtMap extends window.HTMLElement {
       if (data !== undefined && data !== null && data.content !== null) {
         if (type === "wordpress") {
           this.innerHTML = `<div class="cagov-drought-map">
-                <p class="map-label">Released ${latestDroughtMap.dateString}</p>
+                <p class="map-label">Released ${latestDroughtMap.dateString}. Updates automatically each Thursday.</p>
 
                 <p>Click the map to see the intensity of drought conditions in California:</p>
                 <div class="drought-map-container">
-                  <div class="drought-map-image"><a href="https://droughtmonitor.unl.edu/"><img src="${latestDroughtMap.filePath}" /></a></div>
+                  <div class="drought-map-image"><a href="https://droughtmonitor.unl.edu/CurrentMap/StateDroughtMonitor.aspx?CA"><img src="${latestDroughtMap.filePath}" /></a></div>
                   <div class="legend-label"><h4>Intensity</h4></div>
                   <div class="drought-map-legend">
                       <div class="col-1">


### PR DESCRIPTION
Updates "Released..." text and map link on the drought map, per #244.

Should we also update the link for "View details on US Drought Monitor", or leave that pointing to the droughtmonitor.unl.edu homepage as-is?