### PR TITLE
Override feature-card max-height

### DIFF
--- a/src/css/sass/index.scss
+++ b/src/css/sass/index.scss
@@ -22,3 +22,5 @@
 @import "../../../node_modules/@cagov/ds-agency-footer/src/index.scss";
 @import "../../../node_modules/@cagov/ds-statewide-footer/src/index.scss";
 @import "../../../node_modules/@cagov/ds-dropdown-menu/src/index.scss";
+
+@import "./site-overrides.scss";

--- a/src/css/sass/site-overrides.scss
+++ b/src/css/sass/site-overrides.scss
@@ -1,0 +1,3 @@
+.cagov-featured-image {
+  max-height: none;
+}


### PR DESCRIPTION
This PR is a temporary fix to the image padding problem with the feature-card on the homepage.

Current:
<img width="1153" alt="Screen Shot 2022-02-10 at 12 08 51" src="https://user-images.githubusercontent.com/1208960/153488370-f94747c6-0451-43b0-a617-6dc067dcdbf8.png">

Temp fix:
<img width="1161" alt="Screen Shot 2022-02-10 at 12 09 01" src="https://user-images.githubusercontent.com/1208960/153488410-0be4885c-5714-4dde-94e7-a122d18560de.png">

We should ultimately address this in the Design System instead of here on Drought.

Also, this doesn't yet address the discrepancies between production and staging as reported in #264.


