### PR TITLE
Update GitHub workflows to Node 16

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -16,10 +16,10 @@ jobs:
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
-      - name: Use Node.js 14.17.0
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.0
+          node-version: 16
       - name: Build 11ty
         run: |
           mkdir dist

--- a/.github/workflows/eleventy_build_development.yml
+++ b/.github/workflows/eleventy_build_development.yml
@@ -11,10 +11,10 @@ jobs:
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
-      - name: Use Node.js 14.17.0
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.0
+          node-version: 16
       - name: Build 11ty
         run: |
           npm ci --production

--- a/.github/workflows/eleventy_build_main_test_pantheon.yml
+++ b/.github/workflows/eleventy_build_main_test_pantheon.yml
@@ -14,10 +14,10 @@ jobs:
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
-      - name: Use Node.js 14.17.0
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.0
+          node-version: 16
       - name: Build 11ty
         run: |
           mkdir dist

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -14,10 +14,10 @@ jobs:
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
-      - name: Use Node.js 14.17.0
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.0
+          node-version: 16
       - name: Get branch name (merge)
         if: github.event_name != 'pull_request'
         shell: bash

--- a/.github/workflows/eleventy_build_staging.yml
+++ b/.github/workflows/eleventy_build_staging.yml
@@ -11,10 +11,10 @@ jobs:
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
-      - name: Use Node.js 14.17.0
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.0
+          node-version: 16
       - name: Build 11ty
         run: |
           mkdir dist

--- a/.github/workflows/fetch-drought-data.yml
+++ b/.github/workflows/fetch-drought-data.yml
@@ -27,10 +27,10 @@ jobs:
           curl -o src/components/spei-map/WGS84.png https://cww.water.ca.gov/resources/images/map/WGS84.png
           curl -o src/components/spei-map/updated.json https://cww.water.ca.gov/?dataservice=speimap
       
-      - name: Use Node.js 14.17.0
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.0
+          node-version: 16
 
       - name: Process files
         run: |


### PR DESCRIPTION
Updates all GitHub Action workflows to version 16 of Node. This is necessary to avoid an error with esbuild.