### PR TITLE
Remove WP's auto-lazy from feature-card image

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,7 +6,6 @@ const config = require('./odi-publishing/config.js');
 const renderPostLists = require("./src/components/post-list/render");
 const renderReservoirLevels = require("./src/components/reservoir-levels/render");
 const renderSnowpackLevels = require("./src/components/snowpack-levels/render");
-// const renderPrecipitationLevels = require("./src/components/precipitation-levels/render");
 const renderSpeiMapData = require("./src/components/spei-map/render");
 
 module.exports = function (eleventyConfig) {
@@ -86,20 +85,22 @@ module.exports = function (eleventyConfig) {
       if (html.includes("<drought-snowpack-levels")) {
         html = renderSnowpackLevels(html);
       }
-      /* 
-      // Render precipitation-levels
-      if (html.includes("<drought-precipitation-levels")) {
-        html = renderPrecipitationLevels(html);
-      }
-      */
       // Render spei-map
       if (html.includes("<drought-spei-map")) {
         html = renderSpeiMapData(html);
+      }
+      // Remove WP auto-lazy images for the homepage banner.
+      if (html.includes("<img loading=\"lazy\" class=\"cagov-featured-image\"")) {
+        html = html.replace(
+          "<img loading=\"lazy\" class=\"cagov-featured-image\"",
+          "<img class=\"cagov-featured-image\"" 
+        );
       }
 
       // Replace Wordpress media paths with correct 11ty output path.
       const regexPattern = `http.+?pantheonsite\.io/${config.build.upload_folder}`;
       html = html.replace(new RegExp(regexPattern, 'g'), "/media/");
+
       // Minify HTML.
       html = htmlmin.minify(html, {
         useShortDoctype: true,


### PR DESCRIPTION
Wordpress automatically adds `loading="lazy"` to all images, even those included via HTML snippet. That's usually good. But it's bad for images that appear above the fold, where lazy loading can delay first paint.

This PR strips `loading="lazy"` out of any images in the feature-card component, since that component is always used above the fold. This should slightly improve performance.

