### PR TITLE
Better data-viz accessibility

### DIFF
--- a/src/components/data-viz-base/styles.css
+++ b/src/components/data-viz-base/styles.css
@@ -2,6 +2,7 @@
   position: absolute;
   display: flex;
   flex-direction: column-reverse;
+  row-gap: .5rem;
   left: -10000px;
   top: auto;
   width: 1px;

--- a/src/components/data-viz-base/temp-full-homepage-example.html
+++ b/src/components/data-viz-base/temp-full-homepage-example.html
@@ -33,24 +33,24 @@
                       Reservoirs get us through the dry months
                   </p>
               </div>
-              <drought-reservoir-levels class="data-viz-placement">
-                  <p slot="current-level" class="current-level">
-                      <span id="current-percentage" class="data-viz-pct"></span><br />
-                      of average levels
-                  </p>
-                  <table slot="table-data" id="reservoir-data-table">
-                      <caption>
-                          A caption for this data.
-                      </caption>
-                      <thead>
-                          <tr>
-                              <th id="capacity-taf-heading">Total capacity</th>
-                              <th id="historical-taf-heading">Average level historically</th>
-                              <th id="current-taf-heading">Current level</th>
-                          </tr>
-                      </thead>
-                  </table>
-              </drought-reservoir-levels>
+              <div class="data-viz-placement">
+                <drought-reservoir-levels>
+                    <h5 slot="summary-header">Summary of current level</h5>
+                    <p slot="summary-stat" class="current-level">
+                        <span class="data-viz-pct"></span><br>
+                        of average levels
+                    </p>
+  
+                    <h5 slot="capacity-header">Total capacity</h5>
+                    <p slot="capacity-stat">40,673 thousands of acre feet (TAF)</p>
+  
+                    <h5 slot="historical-header">Average level historically</h5>
+                    <p slot="historical-stat">56,598 thousands of acre feet (TAF)</p>
+  
+                    <h5 slot="current-header">Current level</h5>
+                    <p slot="current-stat">75,534 thousands of acre feet (TAF)</p>
+                </drought-reservoir-levels>
+              </div>
               <div class="data-viz-footer">
                   <p class="data-viz-freq">
                       Updated daily
@@ -72,28 +72,21 @@
                       Snow melt feeds our reservoirs &amp; rivers
                   </p>
               </div>
-              <drought-snowpack-levels>
-                  <p slot="current-level" class="current-level current-level-flex">
-                      <span id="current-percentage" class="data-viz-pct"></span>
-                      <span>of average peak snowpack</span>
-                  </p>
-                  <table slot="table-data" id="snowpack-data-table">
-                      <caption>
-                          A caption for this data.
-                      </caption>
-                      <thead>
-                          <tr>
-                              <th id="snowpack-historic-header">
-                                  Average peak snow water equivalent<br /> 
-                                  from 1991–2020
-                              </th>
-                              <th id="snowpack-current-header">
-                                  Current snow water equivalent
-                              </th>
-                          </tr>
-                      </thead>
-                  </table>
-              </drought-snowpack-levels>
+              <div class="data-viz-placement">
+                <drought-snowpack-levels>
+                    <h5 slot="summary-header">Summary of current level</h5>
+                    <p slot="summary-stat" class="current-level current-level-flex">
+                        <span class="data-viz-pct"></span>
+                        <span>of average peak snowpack</span>
+                    </p>
+
+                    <h5 slot="historic-peak-header">Average peak snow water equivalent<br>from 1991–2020</h5>
+                    <p slot="historic-peak-stat">25.3 inches</p>
+  
+                    <h5 slot="current-header">Current snow water equivalent</h5>
+                    <p slot="current-stat">1.2 inches</p>
+                </drought-snowpack-levels>
+              </div>
               <div class="data-viz-footer">
                   <p class="data-viz-freq">
                       Updated daily

--- a/src/components/reservoir-levels/index.js
+++ b/src/components/reservoir-levels/index.js
@@ -25,41 +25,19 @@ class DroughtReservoirLevels extends DroughtDataVizBase {
     const fullWidth = 150;
     const fullHeight = 150;
 
-    const waterLegendText = this.querySelector('#current-taf-heading').innerHTML;
-    const waterContent = this.querySelector('.reservoir-current').innerHTML;
-    const waterPopOver = this.buildPopOverElement({
-      container,
-      x: `${((fullWidth - 28) / fullWidth) * 100}%`,
-      y: `70%`,
-      xOffsetM: '65%',
-      content: waterContent,
-      legendText: waterLegendText,
-      legendSvg: `
-        <svg width="13" height="13" viewBox="0 0 10 10" aria-hidden="true">
-          <rect x="0" y="0" width="10" height="10" class="filled" />
-        </svg>
-      `
-    });
+    const waterPopOver = this.shadowRoot.querySelector('#current-popover');
+    const waterPopOverX = ((fullWidth - 28) / fullWidth) * 100;
+    waterPopOver.setAttribute('style', `--x:${waterPopOverX}%; --y:70%; --x-offset-m:65%;`);
+
     const water = this.shadowRoot.querySelector('#basin-water');
     water.setAttribute('y', waterLevelY);
     water.setAttribute('height', waterHeight);
     this.setUpPopOvers(waterPopOver, water);
 
-    const historicalLegendText = this.querySelector('#historical-taf-heading').innerHTML;
-    const historicalContent = this.querySelector('.reservoir-historic').innerHTML;
-    const historicalPopOver = this.buildPopOverElement({
-      container,
-      x: `${((fullWidth - 8) / fullWidth) * 100}%`,
-      y: `23%`,
-      xOffsetM: '65%',
-      content: historicalContent,
-      legendText: historicalLegendText,
-      legendSvg: `
-        <svg width="26" height="13" viewBox="0 0 26 13" aria-hidden="true">
-          <line x1="0" y1="7" x2="26" y2="7" stroke-width="2" stroke-dasharray="2 4" stroke-linecap="round" class="historical" />
-        </svg>
-      `
-    });
+    const historicalPopOver = this.shadowRoot.querySelector('#historical-popover');
+    const historicalPopOverX = ((fullWidth - 8) / fullWidth) * 100;
+    historicalPopOver.setAttribute('style', `--x:${historicalPopOverX}%; --y:23%; --x-offset-m:65%;`);
+
     const historicalLine = this.shadowRoot.querySelector('#historical-line');
     const historicalHoverTarget = this.shadowRoot.querySelector('#historical-line-hover-target');
     historicalLine.setAttribute('y1', historicalLineY);
@@ -67,21 +45,10 @@ class DroughtReservoirLevels extends DroughtDataVizBase {
     historicalHoverTarget.setAttribute('y', historicalLinePadY);
     this.setUpPopOvers(historicalPopOver, historicalHoverTarget);
 
-    const basinLegendText = this.querySelector('#capacity-taf-heading').innerHTML;
-    const basinContent = this.querySelector('.reservoir-capacity').innerHTML;
-    const basinPopOver = this.buildPopOverElement({
-      container,
-      x: `${((fullWidth - 8) / fullWidth) * 100}%`,
-      y: `50%`,
-      xOffsetM: '65%',
-      content: basinContent,
-      legendText: basinLegendText,
-      legendSvg: `
-        <svg width="13" height="13" viewBox="0 0 10 10" aria-hidden="true">
-          <rect x="0" y="0" width="10" height="10" class="capacity" />
-        </svg>
-      `
-    });
+    const basinPopOver = this.shadowRoot.querySelector('#capacity-popover');
+    const basinPopOverX = ((fullWidth - 8) / fullWidth) * 100;
+    basinPopOver.setAttribute('style', `--x:${basinPopOverX}%; --y:50%; --x-offset-m:65%;`);
+
     const basin = this.shadowRoot.querySelector('#basin-capacity');
     this.setUpPopOvers(basinPopOver, basin);
   }

--- a/src/components/reservoir-levels/readme.md
+++ b/src/components/reservoir-levels/readme.md
@@ -40,39 +40,37 @@ We retreive this data via GitHub Action in `.github/workflows/fetch-drought-data
 
 ## How it works
 
-The custom element, `<drought-reservoir-levels>`, accepts two pieces of content: a `<p>` and a `<table>`. The table is then rendered into the data visualization via client-side JavaScript. This approach allows us to acheive excellent progressive enhancement, accessibility, and performance. 
+The custom element, `<drought-reservoir-levels>`, accepts a series of heading/paragraph pairs. These pairs much be tagged with their corresponding `slot` attributes. This content is then rendered into the data visualization via client-side JavaScript. This approach allows us to acheive excellent progressive enhancement, accessibility, and performance. 
 
 ## Code sample
 
-Here's how to add the mark-up to this 11ty-based site.
+Here's some sample mark-up.
 
 ```html 
-<drought-reservoir-levels data-locale="en-US" data-unit="thousands of acre feet (TAF)" data-current-taf="11347" data-historical-taf="17613" data-capacity-taf="23623">
-  <p slot="current-level">
-    <span id="current-percentage" class="data-viz-pct"></span><br />of
-    average levels
+<drought-reservoir-levels data-locale="en-US" data-unit="thousands of acre feet (TAF)" data-current-taf="75534" data-historical-taf="56598" data-capacity-taf="40673">
+  <h5 slot="summary-header">Summary of current level</h5>
+  <p slot="summary-stat" class="current-level">
+    <span class="data-viz-pct">72%</span><br>
+    of average levels
   </p>
-  <table slot="table-data" id="reservoir-data-table">
-    <caption>
-      A caption for this data.
-    </caption>
-    <thead>
-      <tr>
-        <th id="capacity-taf-heading">Total capacity</th>
-        <th id="historical-taf-heading">Average level historically</th>
-        <th id="current-taf-heading">Current level</th>
-      </tr>
-    </thead>
-  </table>
+
+  <h5 slot="capacity-header">Total capacity</h5>
+  <p slot="capacity-stat">40,673 thousands of acre feet (TAF)</p>
+
+  <h5 slot="historical-header">Average level historically</h5>
+  <p slot="historical-stat">56,598 thousands of acre feet (TAF)</p>
+
+  <h5 slot="current-header">Current level</h5>
+  <p slot="current-stat">75,534 thousands of acre feet (TAF)</p>
 </drought-reservoir-levels>
 ```
 
 Some things to note.
 
-* 11ty will fill in the table rows via the `render.js` script in this folder.
+* 11ty will fill in the paragraph "stat" values via the `render.js` script in this folder.
   * This `render.js` file is called from the `.eleventy.js` config file for 11ty.
-  * `render.js` will also fill the value for `<span id="current-percentage">`.
-  * The table row data comes from the `majorReservoirConditions.json` file, also in this folder.
+  * `render.js` will also fill the value for `<span class="data-viz-pct">`.
+  * The data comes from the `majorReservoirConditions.json` file, also in this folder.
   * **If migrated to another platform, the processing in `render.js` would need to be replaced by another back-end process.**
 * `data-current-taf`, `data-historical-taf`, and `data-capacity-taf` are all required. These integers are used to calculate display of the SVG data visualization.
   * These attributes are currently added via `render.js`.
@@ -81,34 +79,5 @@ Some things to note.
   * `data-current-taf` is the sum of current water levels across major reservoirs, in TAF. 
 * The `data-locale` and `data-unit` attributes may be omitted for English. These attributes should be used for translating the visualization into other languages, if needed. 
   * [See MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locale_identification_and_negotiation) for more info on possible values for `data-locale`.
-
-If 11ty needs to be replaced with another tool, here's an example of the full HTML mark-up that will be expected by the `<drought-reservoir-levels>` custom element.
-
-```html 
-<drought-reservoir-levels data-locale="en-US" data-unit="thousands of acre feet (TAF)" data-current-taf="11347" data-historical-taf="17613" data-capacity-taf="23623">
-  <p slot="current-level">
-    <span id="current-percentage" class="data-viz-pct">64%</span><br />of
-    average levels
-  </p>
-  <table slot="table-data" id="reservoir-data-table">
-    <caption>
-      A caption for this data.
-    </caption>
-    <thead>
-      <tr>
-        <th id="capacity-taf-heading">Total capacity</th>
-        <th id="historical-taf-heading">Average level historically</th>
-        <th id="current-taf-heading">Current level</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr id="reservoir-data">
-        <td class="reservoir-capacity">23,623 thousands of acre feet (TAF)</td>
-        <td class="reservoir-historic">17,613 thousands of acre feet (TAF)</td>
-        <td class="reservoir-current">11,347 thousands of acre feet (TAF)</td>
-      </tr>
-    </tbody>
-  </table>
-</drought-reservoir-levels>
-```
+* The `slot="summary-header"` element is only for screen readers, or when Javascript is disabled.
 

--- a/src/components/reservoir-levels/render.js
+++ b/src/components/reservoir-levels/render.js
@@ -54,9 +54,7 @@ const renderReservoirLevels = function (html) {
     // Get the locale for translating number display, if needed. Commas, decimals, etc.
     const locale = $("drought-reservoir-levels").data("locale") || "en-US";
 
-    const unit =
-      $("drought-reservoir-levels").data("unit") ||
-      "thousands of acre feet (TAF)";
+    const unit = $("drought-reservoir-levels").data("unit") || "thousands of acre feet (TAF)";
 
     // Set data values on the component.
     $("drought-reservoir-levels")
@@ -64,23 +62,18 @@ const renderReservoirLevels = function (html) {
       .attr("data-historical-taf", historicalTAF)
       .attr("data-capacity-taf", capacityTAF);
 
-    $("#reservoir-data-table").append(`
-      <tr id="reservoir-data">
-        <td class="reservoir-capacity">
-          ${capacityTAF.toLocaleString(locale)} ${unit}
-        </td>
-        <td class="reservoir-historic">
-          ${historicalTAF.toLocaleString(locale)} ${unit}
-        </td>
-        <td class="reservoir-current">
-          ${currentTAF.toLocaleString(locale)} ${unit}
-        </td>
-      </tr>
-    `);
-
     // If these placeholders are present within the provided mark-up, fill them with real values.
-    if ($("#current-percentage").length) {
-      $("#current-percentage").text(`${currentPercentage}%`);
+    if ($(".data-viz-pct").length) {
+      $(".data-viz-pct").text(`${currentPercentage}%`);
+    }
+    if ($("[slot=capacity-stat]").length) {
+      $("[slot=capacity-stat]").text(`${capacityTAF.toLocaleString(locale)} ${unit}`);
+    }
+    if ($("[slot=historical-stat]").length) {
+      $("[slot=historical-stat]").text(`${historicalTAF.toLocaleString(locale)} ${unit}`);
+    }
+    if ($("[slot=current-stat]").length) {
+      $("[slot=current-stat]").text(`${currentTAF.toLocaleString(locale)} ${unit}`);
     }
 
     result = result.replace(originalMarkup, $.html());

--- a/src/components/reservoir-levels/styles.css
+++ b/src/components/reservoir-levels/styles.css
@@ -1,6 +1,6 @@
 .reservoir-data-viz {
   display: flex;
-  flex-direction: row;
+  flex-direction: row-reverse;
   align-items: center;
   column-gap: 1rem;
 }

--- a/src/components/reservoir-levels/template.html
+++ b/src/components/reservoir-levels/template.html
@@ -1,6 +1,13 @@
 <div class="reservoir-data-viz">
-  <div class="reservoir-data-viz-graphic popover-container" aria-hidden="true">
-    <svg width="150" height="150" viewBox="0 0 150 150">
+  <div class="reservoir-data-viz-overall">
+    <div class="sr-only">
+      <slot name="summary-header"></slot>
+    </div>
+    <slot name="summary-stat"></slot>
+  </div>
+
+  <div class="reservoir-data-viz-graphic popover-container">
+    <svg width="150" height="150" viewBox="0 0 150 150" aria-hidden="true">
       <defs>
         <!-- Clip in rounded corners on the bottom of the water. -->
         <clipPath id="rounded-water-bottom">
@@ -16,12 +23,36 @@
       <!-- Draw an invisible rectangle over the line, to help people hover over it. -->
       <rect id="historical-line-hover-target" x="0" y="0" width="150" height="10" />
     </svg>
+
+    <div tabindex="0" id="capacity-popover" class="popover-content">
+      <div class="popover-legend">
+        <svg width="13" height="13" viewBox="0 0 10 10" aria-hidden="true">
+          <rect x="0" y="0" width="10" height="10" class="capacity"></rect>
+        </svg>
+        <slot name="capacity-header"></slot>
+      </div>
+      <slot name="capacity-stat"></slot>
+    </div>
+  
+    <div tabindex="0" id="historical-popover" class="popover-content">
+      <div class="popover-legend">
+        <svg width="26" height="13" viewBox="0 0 26 13" aria-hidden="true">
+          <line x1="0" y1="7" x2="26" y2="7" stroke-width="2" stroke-dasharray="2 4" stroke-linecap="round" class="historical"></line>
+        </svg>
+        <slot name="historical-header"></slot>
+      </div>
+      <slot name="historical-stat"></slot>
+    </div>
+  
+    <div tabindex="0" id="current-popover" class="popover-content">
+      <div class="popover-legend">
+        <svg width="13" height="13" viewBox="0 0 10 10" aria-hidden="true">
+          <rect x="0" y="0" width="10" height="10" class="filled"></rect>
+        </svg>
+        <slot name="current-header"></slot>
+      </div>
+      <slot name="current-stat"></slot>
+    </div>
   </div>
 
-  <div class="reservoir-data-viz-overall">
-    <slot name="current-level"></slot>
-  </div>
-</div>
-<div class="sr-only">
-  <slot name="table-data"></slot>
 </div>

--- a/src/components/snowpack-levels/index.js
+++ b/src/components/snowpack-levels/index.js
@@ -127,20 +127,11 @@ class DroughtSnowpackLevels extends DroughtDataVizBase {
     currentCircleHoverTarget.setAttribute('id', 'current-terminus-hover-target');
     graph.append(currentCircleHoverTarget);
 
-    const currentLegendText = this.querySelector('#snowpack-current-header').innerHTML;
-    const currentContent = this.querySelector('.snowpack-current').innerHTML;
-    const currentPopOver = this.buildPopOverElement({
-      container,
-      x: `${((currentCircleX + 15) / fullWidth) * 100}%`,
-      y: `${((currentCircleY) / fullHeight) * 100}%`,
-      content: currentContent,
-      legendText: currentLegendText,
-      legendSvg: `
-        <svg width="26" height="13" viewBox="0 0 26 13" aria-hidden="true">
-          <line x1="0" y1="7" x2="26" y2="7" stroke-linecap="round" class="current" />
-        </svg>
-      `
-    });
+    // Get the pop-over content for the current level.
+    const currentPopOver = this.shadowRoot.querySelector('#current-popover');
+    const currentPopOverX = ((currentCircleX + 15) / fullWidth) * 100;
+    const currentPopOverY = ((currentCircleY) / fullHeight) * 100;
+    currentPopOver.setAttribute('style', `--x:${currentPopOverX}%; --y:${currentPopOverY}%; --x-offset-m:0%;`);
     this.setUpPopOvers(currentPopOver, currentCircleHoverTarget);
 
     // Add the "historic peak" text next to the above circle.
@@ -168,21 +159,11 @@ class DroughtSnowpackLevels extends DroughtDataVizBase {
     peakCircleHoverTarget.setAttribute('id', 'historic-peak-hover-target');
     graph.append(peakCircleHoverTarget);
 
-    // Build the pop-over for historic peak.
-    const historicLegendText = this.querySelector('#snowpack-historic-header').innerHTML;
-    const historicContent = this.querySelector('.snowpack-historic').innerHTML;
-    const historicPeakPopOver = this.buildPopOverElement({
-      container,
-      x: `${((peakX + 15) / fullWidth) * 100}%`,
-      y: `${(peakY / fullHeight) * 100}%`,
-      content: historicContent,
-      legendText: historicLegendText,
-      legendSvg: `
-        <svg width="13" height="13" viewBox="0 0 10 10" aria-hidden="true">
-          <circle r="4" cx="5" cy="5" class="peak" />
-        </svg>
-      `
-    });
+    // Get the pop-over content for the historic peak.
+    const historicPeakPopOver = this.shadowRoot.querySelector('#historic-peak-popover');
+    const historicPeakPopOverX = ((peakX + 15) / fullWidth) * 100;
+    const historicPeakPopOverY = (peakY / fullHeight) * 100;
+    historicPeakPopOver.setAttribute('style', `--x:${historicPeakPopOverX}%; --y:${historicPeakPopOverY}%; --x-offset-m:0%;`);
     this.setUpPopOvers(historicPeakPopOver, peakCircleHoverTarget);
   }
 }

--- a/src/components/snowpack-levels/readme.md
+++ b/src/components/snowpack-levels/readme.md
@@ -18,71 +18,40 @@ We retreive this data via GitHub Action in `.github/workflows/fetch-drought-data
 
 ## How it works
 
-The custom element, `<drought-snowpack-levels>`, accepts two pieces of content: a `<p>` and a `<table>`. The table is then rendered into the data visualization via client-side JavaScript. This approach allows us to acheive excellent progressive enhancement, accessibility, and performance. 
+The custom element, `<drought-snowpack-levels>`, accepts a series of heading/paragraph pairs. These pairs much be tagged with their corresponding `slot` attributes. This content is then rendered into the data visualization via client-side JavaScript. This approach allows us to acheive excellent progressive enhancement, accessibility, and performance. 
 
 ## Code sample
 
 Here's how to add the mark-up to this 11ty-based site.
 
 ```html
-<drought-snowpack-levels data-unit="inches" data-locale="en-US" data-historic-peak-label="Historic peak">
-  <p slot="current-level" class="snowpack-current-level">
-    <span id="current-percentage" class="data-viz-pct">31%</span>
+<drought-snowpack-levels data-unit="inches" data-locale="en-US" data-historic-peak-label="Historic peak" data-current="1.2" data-historic-peak="25.3">
+  <h5 slot="summary-header">Summary of current level</h5>
+  <p slot="summary-stat" class="current-level current-level-flex">
+    <span class="data-viz-pct">4%</span> 
     <span>of average peak snowpack</span>
   </p>
-  <table slot="table-data" id="snowpack-data-table">
-    <caption>
-      A caption for this data.
-    </caption>
-    <thead>
-      <tr>
-        <th id="snowpack-historic-header">
-          Average peak snow water equivalent<br />from 1991–2020
-        </th>
-        <th id="snowpack-current-header">Current snow water equivalent</th>
-      </tr>
-    </thead>
-  </table>
+
+  <h5 slot="historic-peak-header">Average peak snow water equivalent<br>from 1991–2020</h5>
+  <p slot="historic-peak-stat">25.3 inches</p>
+  
+  <h5 slot="current-header">Current snow water equivalent</h5>
+  <p slot="current-stat">1.2 inches</p>
 </drought-snowpack-levels>
 ```
 
 Some things to note.
 
-* 11ty will fill in the table rows via the `render.js` script in this folder.
+* 11ty will fill in the paragraph "stat" values via the `render.js` script in this folder.
   * This `render.js` file is called from the `.eleventy.js` config file for 11ty.
-  * `render.js` will also fill the value for `<span id="current-percentage">`.
-  * The table row data comes from `snowpackConditions.json` file, also in this folder.
+  * `render.js` will also fill the value for `<span class="data-viz-pct">`.
+  * The data comes from `snowpackConditions.json` file, also in this folder.
   * **If migrated to another platform, the processing in `render.js` would need to be replaced by another back-end process.**
+* `data-current` and `data-historic-peak` are required. These numbers are used to calculate display of the SVG data visualization.
+  * These attributes are currently added via `render.js`.
+  * `data-current` is the current snowpack level in inches.
+  * `data-historic-peak` is the historical average of peak snowpack, typically measured on April 1st, in inches.
 * `data-historic-peak-label` is optional, and will default to "Historic peak". Use this data attribute to change the label for translated versions.
 * The `data-locale` and `data-unit` attributes may be omitted for English too. These attributes should be used for translating the visualization into other languages, if needed. 
   * [See MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locale_identification_and_negotiation) for more info on possible values for `data-locale`.
-
-If 11ty needs to be replaced with another tool, here's an example of the full HTML mark-up that will be expected by the `<drought-snowpack-levels>` custom element.
-
-```html
-<drought-snowpack-levels data-unit="inches" data-locale="en-US" data-historic-peak-label="Historic peak">
-  <p slot="current-level" class="snowpack-current-level">
-    <span id="current-percentage" class="data-viz-pct">31%</span>
-    <span>of average peak snowpack</span>
-  </p>
-  <table slot="table-data" id="snowpack-data-table">
-    <caption>
-      A caption for this data.
-    </caption>
-    <thead>
-      <tr>
-        <th id="snowpack-historic-header">
-          Average peak snow water equivalent<br />from 1991–2020
-        </th>
-        <th id="snowpack-current-header">Current snow water equivalent</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr id="snowpack-data" data-current="8.8" data-historic-peak="25.3">
-        <td class="snowpack-historic">25.3 inches</td>
-        <td class="snowpack-current">8.8 inches</td>
-      </tr>
-    </tbody>
-  </table>
-</drought-snowpack-levels>
-```
+* The `slot="summary-header"` element is only for screen readers, or when Javascript is disabled.

--- a/src/components/snowpack-levels/render.js
+++ b/src/components/snowpack-levels/render.js
@@ -30,18 +30,28 @@ const renderSnowpackLevels = function (html) {
     const unit = $("drought-snowpack-levels").data('unit') || "inches";
     $("drought-snowpack-levels").attr("data-unit", unit);
 
-    $('#snowpack-data-table').append(`
-      <tr id="snowpack-data" 
-        data-current="${latestEntry.avgSwc.toFixed(1)}" 
-        data-historic-peak="${historicPeak.avgAvgSwc.toFixed(1)}">
-        <td class="snowpack-historic">${historicPeak.avgAvgSwc.toFixed(1)} ${unit}</td>
-        <td class="snowpack-current">${latestEntry.avgSwc.toFixed(1)} ${unit}</td>
-      </tr>
-    `);
+    // Get the locale for translating number display, if needed. Commas, decimals, etc.
+    const locale = $("drought-reservoir-levels").data("locale") || "en-US";
+    $("drought-snowpack-levels").attr("data-locale", locale);
+
+    // Format to single decimal.
+    const currentLevel = latestEntry.avgSwc.toFixed(1);
+    const historicPeakLevel = historicPeak.avgAvgSwc.toFixed(1);
+
+    // Set data values on the component.
+    $("drought-snowpack-levels")
+      .attr("data-current", currentLevel)
+      .attr("data-historic-peak", historicPeakLevel);
 
     // If this placeholder is present within the provided mark-up, fill it with value.
-    if ($("#current-percentage").length) {
-      $("#current-percentage").text(`${latestEntry.pctApr1}%`);
+    if ($(".data-viz-pct").length) {
+      $(".data-viz-pct").text(`${latestEntry.pctApr1}%`);
+    }
+    if ($("[slot=current-stat]").length) {
+      $("[slot=current-stat]").text(`${currentLevel.toLocaleString(locale)} ${unit}`);
+    }
+    if ($("[slot=historic-peak-stat]").length) {
+      $("[slot=historic-peak-stat]").text(`${historicPeakLevel.toLocaleString(locale)} ${unit}`);
     }
 
     result = result.replace(originalMarkup, $.html());

--- a/src/components/snowpack-levels/template.html
+++ b/src/components/snowpack-levels/template.html
@@ -1,10 +1,13 @@
 <div class="snowpack-data-viz">
   <div class="snowpack-data-viz-overall">
-    <slot name="current-level"></slot>
+    <div class="sr-only">
+      <slot name="summary-header"></slot>
+    </div>
+    <slot name="summary-stat"></slot>
   </div>
 
-  <div class="popover-container" aria-hidden="true">
-    <svg id="snowpack-graph" width="365" height="175" viewBox="0 0 365 175">
+  <div class="popover-container">
+    <svg id="snowpack-graph" width="365" height="175" viewBox="0 0 365 175" aria-hidden="true">
       <line x1="0" y1="145" x2="365" y2="145" stroke-width="1" />
   
       <line x1="31" y1="0" x2="31" y2="145" stroke-width="1" />
@@ -25,8 +28,26 @@
       <line x1="335" y1="0" x2="335" y2="145" stroke-width="1" />
       <text x="335" y="160" dominant-baseline="middle" id="snowpack-month-9" text-anchor="middle"></text>
     </svg>
+  
+    <div tabindex="0" id="historic-peak-popover" class="popover-content">
+      <div class="popover-legend">
+        <svg width="13" height="13" viewBox="0 0 10 10" aria-hidden="true">
+          <circle r="4" cx="5" cy="5" class="peak" />
+        </svg>
+        <slot name="historic-peak-header"></slot>
+      </div>
+      <slot name="historic-peak-stat"></slot>
+    </div>
+
+    <div tabindex="0" id="current-popover" class="popover-content">
+      <div class="popover-legend">
+        <svg width="26" height="13" viewBox="0 0 26 13" aria-hidden="true">
+          <line x1="0" y1="7" x2="26" y2="7" stroke-linecap="round" class="current" />
+        </svg>
+        <slot name="current-header"></slot>
+      </div>
+      <slot name="current-stat"></slot>
+    </div>
+    
   </div>
-</div>
-<div class="sr-only">
-  <slot name="table-data"></slot>
 </div>

--- a/src/css/sass/data-visualizations.scss
+++ b/src/css/sass/data-visualizations.scss
@@ -1,19 +1,25 @@
-drought-reservoir-levels:defined .data-viz-pct,
-drought-snowpack-levels:defined .data-viz-pct {
-  font-size: 3rem;
-  font-weight: 700;
-}
-
-drought-reservoir-levels:defined .current-level,
-drought-snowpack-levels:defined .current-level {
-  font-size: 1.1rem;
-  margin: 0;
-  &-flex {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    column-gap: .25rem;
-    line-height: 1.3;
+drought-reservoir-levels:defined,
+drought-snowpack-levels:defined {
+  .data-viz-pct {
+    font-size: 3rem;
+    font-weight: 700;
+  }
+  .current-level {
+    font-size: 1.1rem;
+    margin: 0;
+    &-flex {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      column-gap: .25rem;
+      line-height: 1.3;
+    }
+  }
+  h2, h3, h4, h5, h6 {
+    margin: 0;
+    font-weight: 400;
+    font-size: 1em;
+    line-height: unset;
   }
 }
 
@@ -136,7 +142,7 @@ drought-spei-map {
   &-placement {
     flex-grow: 5;
     display: flex;
-    margin: 1rem 0;
+    align-items: center;
     table, td, th {
       font-size: .8em;
       border-collapse: collapse;

--- a/src/templates/wordpress/pages/homepage.html
+++ b/src/templates/wordpress/pages/homepage.html
@@ -65,24 +65,24 @@
                       Reservoirs get us through the dry months
                   </p>
               </div>
-              <drought-reservoir-levels class="data-viz-placement">
-                  <p slot="current-level" class="current-level">
-                      <span id="current-percentage" class="data-viz-pct"></span><br>
-                      of average levels
-                  </p>
-                  <table slot="table-data" id="reservoir-data-table">
-                      <caption>
-                           A chart that shows total major reservoir levels. 
-                      </caption>
-                      <thead>
-                          <tr>
-                              <th id="capacity-taf-heading">Total capacity</th>
-                              <th id="historical-taf-heading">Average level historically</th>
-                              <th id="current-taf-heading">Current level</th>
-                          </tr>
-                      </thead>
-                  </table>
-              </drought-reservoir-levels>
+              <div class="data-viz-placement">
+                <drought-reservoir-levels>
+                    <h5 slot="summary-header">Summary of current level</h5>
+                    <p slot="summary-stat" class="current-level">
+                        <span class="data-viz-pct"></span><br>
+                        of average levels
+                    </p>
+  
+                    <h5 slot="capacity-header">Total capacity</h5>
+                    <p slot="capacity-stat">40,673 thousands of acre feet (TAF)</p>
+  
+                    <h5 slot="historical-header">Average level historically</h5>
+                    <p slot="historical-stat">56,598 thousands of acre feet (TAF)</p>
+  
+                    <h5 slot="current-header">Current level</h5>
+                    <p slot="current-stat">75,534 thousands of acre feet (TAF)</p>
+                </drought-reservoir-levels>
+              </div>
               <div class="data-viz-footer">
                   <p class="data-viz-freq">
                       Updated daily
@@ -104,28 +104,21 @@
                       Snow melt feeds our reservoirs &amp; rivers
                   </p>
               </div>
-              <drought-snowpack-levels>
-                  <p slot="current-level" class="current-level current-level-flex">
-                      <span id="current-percentage" class="data-viz-pct"></span>
-                      <span>of average peak snowpack</span>
-                  </p>
-                  <table slot="table-data" id="snowpack-data-table">
-                      <caption>
-                          A chart of current snowpack level compared to the historic April 1 peak.
-                      </caption>
-                      <thead>
-                          <tr>
-                              <th id="snowpack-historic-header">
-                                  Average peak snow water equivalent<br> 
-                                  from 1991–2020
-                              </th>
-                              <th id="snowpack-current-header">
-                                  Current snow water equivalent
-                              </th>
-                          </tr>
-                      </thead>
-                  </table>
-              </drought-snowpack-levels>
+              <div class="data-viz-placement">
+                <drought-snowpack-levels>
+                    <h5 slot="summary-header">Summary of current level</h5>
+                    <p slot="summary-stat" class="current-level current-level-flex">
+                        <span class="data-viz-pct"></span>
+                        <span>of average peak snowpack</span>
+                    </p>
+
+                    <h5 slot="historic-peak-header">Average peak snow water equivalent<br>from 1991–2020</h5>
+                    <p slot="historic-peak-stat">25.3 inches</p>
+  
+                    <h5 slot="current-header">Current snow water equivalent</h5>
+                    <p slot="current-stat">1.2 inches</p>
+                </drought-snowpack-levels>
+              </div>
               <div class="data-viz-footer">
                   <p class="data-viz-freq">
                       Updated daily

--- a/src/templates/wordpress/pages/homepage.html
+++ b/src/templates/wordpress/pages/homepage.html
@@ -1,13 +1,13 @@
-<div class="wp-block-ca-design-system-feature-card cagov-with-sidebar cagov-with-sidebar-left cagov-featured-section cagov-bkgrd-gry cagov-block wp-block-ca-design-system-hero"><div><div class="cagov-stack cagov-p-2 cagov-featured-sidebar"><h2>Dry start to 2022 marks third year of drought</h2><div class="cagov-feature-card-body-content">
+<div class="wp-block-ca-design-system-feature-card cagov-with-sidebar cagov-with-sidebar-left cagov-featured-section cagov-bkgrd-gry cagov-block wp-block-ca-design-system-hero"><div><div class="cagov-stack cagov-p-2 cagov-featured-sidebar"><h2>Newsom urges water leaders, Californians to conserve more or face tighter restrictions</h2><div class="cagov-feature-card-body-content">
 
-<p>This year California had the driest January, February, and March ever recorded. Warm days melted snow faster than expected. On April 1, this important source of water was down to 38% of average, and is dropping daily. Find out more:</p>
+<p>As California grapples with three consecutive years of drought, Governor Newsom warned that the state could be forced to enact mandatory restrictions unless water use declines significantly this summer. Learn more about the Governor’s summit with local water leaders.</p>
 
-<div class="wp-block-button"><a class="wp-block-button__link" href="/current-drought-conditions">See current conditions</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link" href="https://www.gov.ca.gov/2022/05/23/governor-newsom-convenes-summit-with-local-water-leaders-urges-more-aggressive-response-to-ongoing-drought/">Read the news release</a></div>
 
 </div></div><div>
 <figure>
-<img loading="lazy" class="cagov-featured-image" src="https://drought.ca.gov/media/2022/04/2022_04_01_FL_0104_Snow_Survey.webp" alt="On April 1, 2022, four state officials stand on dry ground with no snow in the Sierra Nevada Mountains. One is holding a 5-foot-long metal stick, which shows how high the snowpack would normally be at this time of year." width="800" height="533">
-<figcaption><em>Instead of dry ground, these water officials should be standing on 5 feet of snowpack. Taken at the April 1, 2022 snow survey in the Sierra Nevada Mountains.</em></figcaption>
+<img loading="lazy" class="cagov-featured-image" src="https://drought.ca.gov/media/2022/05/SummerWaterSupply2019-2021b.jpg" alt="Side-by-side photos show the effect severe drought has had on one reservoir. On the left, Lake Oroville is full of blue water with the text SUMMER WATER SUPPLY IN 2019. On the right, that same reservoir is shown with barely a trickle of water at the bottom of it, and where there used to be water, there are banks of dry dirt. This image has the text SUMMER WATER SUPPLY IN SEVERE DROUGHT 2021." width="800" height="533">
+<figcaption><em>These photos show the effect severe drought has had on the summer water supply in Lake Oroville.</em></figcaption>
 </figure>
 </div></div></div>
 
@@ -65,24 +65,24 @@
                       Reservoirs get us through the dry months
                   </p>
               </div>
-              <div class="data-viz-placement">
-                <drought-reservoir-levels>
-                    <h5 slot="summary-header">Summary of current level</h5>
-                    <p slot="summary-stat" class="current-level">
-                        <span class="data-viz-pct"></span><br>
-                        of average levels
-                    </p>
-  
-                    <h5 slot="capacity-header">Total capacity</h5>
-                    <p slot="capacity-stat">40,673 thousands of acre feet (TAF)</p>
-  
-                    <h5 slot="historical-header">Average level historically</h5>
-                    <p slot="historical-stat">56,598 thousands of acre feet (TAF)</p>
-  
-                    <h5 slot="current-header">Current level</h5>
-                    <p slot="current-stat">75,534 thousands of acre feet (TAF)</p>
-                </drought-reservoir-levels>
-              </div>
+              <drought-reservoir-levels class="data-viz-placement">
+                  <p slot="current-level" class="current-level">
+                      <span id="current-percentage" class="data-viz-pct"></span><br>
+                      of average levels
+                  </p>
+                  <table slot="table-data" id="reservoir-data-table">
+                      <caption>
+                           A chart that shows total major reservoir levels. 
+                      </caption>
+                      <thead>
+                          <tr>
+                              <th id="capacity-taf-heading">Total capacity</th>
+                              <th id="historical-taf-heading">Average level historically</th>
+                              <th id="current-taf-heading">Current level</th>
+                          </tr>
+                      </thead>
+                  </table>
+              </drought-reservoir-levels>
               <div class="data-viz-footer">
                   <p class="data-viz-freq">
                       Updated daily
@@ -104,21 +104,28 @@
                       Snow melt feeds our reservoirs &amp; rivers
                   </p>
               </div>
-              <div class="data-viz-placement">
-                <drought-snowpack-levels>
-                    <h5 slot="summary-header">Summary of current level</h5>
-                    <p slot="summary-stat" class="current-level current-level-flex">
-                        <span class="data-viz-pct"></span>
-                        <span>of average peak snowpack</span>
-                    </p>
-
-                    <h5 slot="historic-peak-header">Average peak snow water equivalent<br>from 1991–2020</h5>
-                    <p slot="historic-peak-stat">25.3 inches</p>
-  
-                    <h5 slot="current-header">Current snow water equivalent</h5>
-                    <p slot="current-stat">1.2 inches</p>
-                </drought-snowpack-levels>
-              </div>
+              <drought-snowpack-levels>
+                  <p slot="current-level" class="current-level current-level-flex">
+                      <span id="current-percentage" class="data-viz-pct"></span>
+                      <span>of average peak snowpack</span>
+                  </p>
+                  <table slot="table-data" id="snowpack-data-table">
+                      <caption>
+                          A chart of current snowpack level compared to the historic April 1 peak.
+                      </caption>
+                      <thead>
+                          <tr>
+                              <th id="snowpack-historic-header">
+                                  Average peak snow water equivalent<br> 
+                                  from 1991–2020
+                              </th>
+                              <th id="snowpack-current-header">
+                                  Current snow water equivalent
+                              </th>
+                          </tr>
+                      </thead>
+                  </table>
+              </drought-snowpack-levels>
               <div class="data-viz-footer">
                   <p class="data-viz-freq">
                       Updated daily


### PR DESCRIPTION
This PR resolves a problem with keyboard navigation in the new data visualizations. Currently, I am putting some focusable elements in an `aria-hidden="true"` parent. This is generally not a good idea.

To fix this, we need to overhaul the custom element mark-up,  trading table data in exchange for headings and paragraphs. This does change the fall-back progressive enhancement and accessibility content. I think it's still fairly humane.

There should be no visual change.

This change brings the site's Lighthouse Accessibility score up to 100.

A few content changes will also be needed before merging this into `main`.