### PR TITLE
Cache dependencies

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -17,9 +17,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'npm'
       - name: Build 11ty
         run: |
           mkdir dist


### PR DESCRIPTION
Per cagov/odi-engineering#48, this PR uses the GitHub Actions cache to quickly restore npm dependencies, without fetching them fresh on every build.

This is now supported within the [actions/setup-node](https://github.com/actions/setup-node) tool we already use. If this works, it should be easy to implement on the other sites.