### PR TITLE
Offset snowpack graph by date of first snowfall

### DIFF
--- a/src/components/snowpack-levels/index.js
+++ b/src/components/snowpack-levels/index.js
@@ -105,8 +105,14 @@ class DroughtSnowpackLevels extends DroughtDataVizBase {
 
     // Plot a line for current levels.
     const currentPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    let currentInitialXPoint = 0;
+    const [currentFirstCoordinate] = currentPathCoordinates;
+    if (currentFirstCoordinate && currentFirstCoordinate[0] > 1) {
+      // If needed, offset start of line to date of first snowfall.
+      currentInitialXPoint = currentFirstCoordinate[0] - 1;
+    }
     const currentPathD = currentPathCoordinates.map(([x,y]) => `L${x},${y}`).join(' ');
-    currentPath.setAttribute('d', `M0,${floorY} ${currentPathD}`);
+    currentPath.setAttribute('d', `M${currentInitialXPoint},${floorY} ${currentPathD}`);
     currentPath.classList.add('current');
     graph.append(currentPath);
 


### PR DESCRIPTION
Fixes a minor problem with the snowpack data viz. 

The first part of the line for current level suggests a gradual increase in snowpack.

<img width="368" alt="Screenshot 2023-01-03 at 10 58 33" src="https://user-images.githubusercontent.com/1208960/210426727-12af454b-df17-4972-a095-6dc5d8714ddb.png">

We actually have no data until the big storms started hitting. Something like the following might be more accurate.

<img width="366" alt="Screenshot 2023-01-03 at 11 17 00" src="https://user-images.githubusercontent.com/1208960/210426802-2d26414d-92ce-4729-bfed-a310ae779403.png">
