### PR TITLE
Turn off Generate Drought Map job

### DIFF
--- a/.github/workflows/generate-drought-map.yml
+++ b/.github/workflows/generate-drought-map.yml
@@ -1,13 +1,18 @@
+# Discontinued.
+# The newer SPEI map component is processed via JS.
+# See `npm run process:spei-map:img` inside fetch-drought-data.yml.
+
 name: Generate Drought Map
 
 on:
-  schedule:
-    - cron: 0 16 * * 4
+  workflow_dispatch:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: Fetch current date
         id: date
         run: echo "::set-output name=today::$(date +'%Y-%m-%d')"
@@ -20,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9.7'
+          python-version: "3.9.7"
 
       - name: Install dependencies
         run: |
@@ -30,10 +35,9 @@ jobs:
 
       - name: Run script
         run: python src/py/generate-drought-map/process_usmap.py
-        
+
       - name: Commit files
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Weekly drought map for ${{ steps.date.outputs.today }}
           branch: main
-

--- a/.github/workflows/generate-drought-map.yml
+++ b/.github/workflows/generate-drought-map.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
+    steps: 
       - name: Fetch current date
         id: date
         run: echo "::set-output name=today::$(date +'%Y-%m-%d')"
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9.7"
+          python-version: '3.9.7'
 
       - name: Install dependencies
         run: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run script
         run: python src/py/generate-drought-map/process_usmap.py
-
+        
       - name: Commit files
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/src/components/drought-map/index.js
+++ b/src/components/drought-map/index.js
@@ -1,4 +1,5 @@
 // Drought Map
+// Discontinued. Replaced by the SPEI map component.
 
 import latestDroughtMap from '../../templates/_data/latestDroughtMap.json';
 

--- a/src/py/generate-drought-map/readme.md
+++ b/src/py/generate-drought-map/readme.md
@@ -1,5 +1,11 @@
 # Generating the drought map
 
+## Discontinued
+
+Note that this component has been replaced by the JavaScript-based SPEI map component.
+
+## Intro
+
 This `process_usmap.py` script generates a drought map for use on the site. We run this script once per week. For example:
 
 ![A map of the United States, illustrating which areas are most affected by current drought conditions](https://raw.githubusercontent.com/cagov/drought.ca.gov/main/src/assets/img/usdm-assets/20210817_usdm_excerpt.png)


### PR DESCRIPTION
Since the drought map has been fully replaced by the SPEI map, we no longer need this Python-based Github Actions workflow. This PR removes the current cron in favor of a manual trigger.