### PR TITLE
Turned on HideAuthorName.

### DIFF
--- a/odi-publishing/wordpress-to-github.config.json
+++ b/odi-publishing/wordpress-to-github.config.json
@@ -11,6 +11,7 @@
     "MediaPath": "src/wordpress-media",
     "GeneralFilePath": "odi-publishing/general/general.json",
     "ExcludeProperties": ["content", "_links"],
+    "HideAuthorName": true,
     "ApiRequests": [
       {
         "Destination": "src/templates/_data/headerMenu.json",


### PR DESCRIPTION
Turning on HideAuthorName in wordpress-to-github config file, to prevent /users/ API endpoint from being read, so we can turn off this endpoint.